### PR TITLE
Improve build support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,126 @@
 language: cpp
-compiler:
-    - gcc
-    - clang
 
-branches:
-    only:
-        - master
+git:
+    depth: 5
+
+matrix:
+  include: 
+    - os: linux
+      env: COMPILER=g++-4.9 LUA=lua52
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test 
+          packages:
+          - gcc-4.9
+          - g++-4.9  
+          - ninja-build
+          - liblua5.2-dev
+
+    # gcc-5
+    - os: linux
+      env: COMPILER=g++-4.9 LUA=luajit
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test 
+          packages:
+          - gcc-4.9
+          - g++-4.9
+          - ninja-build  
+          - libluajit-5.1-dev 
+
+    # gcc-5
+    - os: linux
+      env: COMPILER=g++-5 LUA=lua52
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test 
+          packages:
+          - gcc-5
+          - g++-5
+          - ninja-build  
+          - liblua5.2-dev  
+
+    # gcc-5
+    - os: linux
+      env: COMPILER=g++-5 LUA=luajit
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test 
+          packages:
+          - gcc-5
+          - g++-5
+          - ninja-build  
+          - libluajit-5.1-dev  
+
+    - os: linux
+      env: COMPILER=clang++-3.6 lua=lua52
+      compiler: clang
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test 
+          - llvm-toolchain-precise-3.6
+          packages:
+          - clang-3.6
+          - ninja-build   
+          - liblua5.2-dev  
+
+    - os: linux
+      env: COMPILER=clang++-3.6 lua=luajit
+      compiler: clang
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test 
+          - llvm-toolchain-precise-3.6
+          packages:
+          - clang-3.6
+          - ninja-build   
+          - libluajit-5.1-dev  
+
+    # Mac OSX
+    - os: osx
+      osx_image: xcode7
+      compiler: clang
+      env: COMPILER=appleclang 
+
+    - os: osx
+      osx_image: xcode6
+      compiler: clang
+      env: COMPILER=appleclang 
+
+    # Test using gcc
+    - os: osx
+      osx_image: xcode7
+      compiler: gcc
+      env: COMPILER=g++-4.9 
+
+    - os: osx
+      compiler: gcc
+      env: COMPILER=g++-5
 
 before_install:
-    - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-    - sudo add-apt-repository -y ppa:saiarcot895/chromium-beta
-    - sudo apt-get --yes update
-    - sudo apt-get --yes install g++-4.8
-    - if [ "$CXX" == "g++" ]; then export CXX=g++-4.8; fi
-    - sudo apt-get --yes install ninja-build
-    - sudo apt-get --yes install liblua5.2-dev
+- source ./install.deps.sh
 
-script: ./bootstrap.py --ci --cxx=$CXX && ninja
+install:
+- install_os_deps
+
+script:
+- echo "Configuration info:"
+- export_compiler_vars
+- ninja --version
+- ./bootstrap.py --ci && ninja
+
+notifications:
+    email:
+        on_success: change
+        on_failure: change
+

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ For maximum ease of use, a script called `single.py` is provided. You can run th
 Sol makes use of C++11/14 features. GCC 4.7 and Clang 3.3 or higher should be able to compile without problems. However, the
 officially supported compilers are:
 
-- GCC 4.8.0, 4.9.0+
-- Clang 3.4
+- GCC 4.9.0+
+- Clang 3.6+
 - Visual Studio 2015 Community (Visual C++ 14.0)
 
 ## Caveats

--- a/install.deps.sh
+++ b/install.deps.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# This script installs and configures the dependencies for the project
+
+case `uname` in 
+    Darwin)     export OS_NAME="osx"    ;;
+    Linux)      export OS_NAME="linux"  ;;
+esac
+
+echo "Building on: ${OS_NAME}"
+
+if env | grep -qE '^(?:TRAVIS|CI)='; then
+#    We're on Travis, intialize variables:
+    echo "Detected CI Build -> CI=${CI}"
+else
+#   We're building locally
+    export CI=false
+    echo "Detected Local Build -> CI=${CI}"
+fi
+
+export_compiler_vars() {
+    case ${COMPILER} in
+        appleclang*) 
+            export CC=clang
+            export CXX=clang++
+        ;;
+
+        clang*)
+            export CC=$(echo ${COMPILER} | sed 's/\+//g')
+            export CXX=${COMPILER}
+        ;;
+
+        g++-*)
+            export CC=$(echo ${COMPILER} | sed 's/\+/c/g')
+            export CXX=${COMPILER} 
+        ;;
+
+        *) echo "Invalid compiler version" ; exit 2 ;;
+    esac
+
+    echo "CC=${CC}"
+    $CC --version
+
+    echo "CXX=${CXX}"
+    $CXX --version
+}
+
+install_os_deps() {
+    # Install all of the OS specific OS dependencies
+    echo "Install: os-based dependencies"
+
+    local wd=`pwd`
+
+    case ${OS_NAME} in
+        osx)
+            export HOMEBREW_NO_EMOJI=1
+
+            echo "brew update ..."; brew update > /dev/null
+
+            case ${COMPILER} in
+                appleclang*) ;;
+
+                g++-5)
+                    brew install gcc5 
+                    brew link gcc5 --overwrite --force
+                ;;
+
+                g++-4.9) ;;
+
+                *) echo "Invalid compiler version" ; exit 2 ;;
+            esac
+
+            brew install ninja lua
+        ;;
+
+        linux) 
+            # no extras currently
+        ;;
+    esac
+
+    cd ${wd}
+}


### PR DESCRIPTION
Tests:

 OS    | Compiler   | Lua Version
 :---- | ---------- | -----------
 Linux | gcc-4.9    | lua52, LuaJIT
 Linux | gcc-5      | lua52, LuaJIT
 Linux | clang-3.6  | lua52, LuaJIT
 OSX   | appleclang | lua52
 OSX   | gcc-4.9*   | lua52
 OSX   | gcc-5      | lua52

\* On OSX out of the box, gcc-4.9 is actually the gcc wrapper around appleclang

The builds do not currently pass, and I am undecided whether or not this makes sense to merge yet. Also, OSX could test LuaJIT but I was undecided on the value. 