### PR TITLE
Add apple-gcc target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ matrix:
           - ninja-build
           - libluajit-5.1-dev
 
+    # clang
     - os: linux
       env: COMPILER=clang++-3.5 LUA_VERSION=lua52
       compiler: clang
@@ -104,8 +105,22 @@ matrix:
     - os: osx
       osx_image: xcode7
       compiler: gcc
+      env: COMPILER=g++-4.9 LUA_VERSION=lua53
+
+    - os: osx
+      osx_image: xcode7
+      compiler: gcc
       env: COMPILER=g++-5 LUA_VERSION=lua53
-      
+
+    - os: osx
+      osx_image: xcode7
+      compiler: clang
+      env: COMPILER=appleclang LUA_VERSION=lua53
+
+  allow_failures:
+    - os: osx
+      compiler: clang 
+
 before_install:
 - source ./install.deps.sh
 


### PR DESCRIPTION
Adds `appleclang` back.. in a way that doesn't break the build.

OSX ships with a "gcc wrapper" around clang in the `g++` variable. This builds properly, so I've added it into the build matrix. I've still no idea why the normal `appleclang` target fails. 

Also, might I suggest turning on the [required status checks](https://github.com/blog/2051-protected-branches-and-required-status-checks)?