### PR TITLE
For some reason, on luajit5.1 these needed to be inline

### DIFF
--- a/sol/compatibility/5.1.0.h
+++ b/sol/compatibility/5.1.0.h
@@ -84,11 +84,11 @@ typedef struct luaL_Buffer_52 {
 
 #define lua_rawlen(L, i) lua_objlen(L, i)
 
-void lua_callk(lua_State *L, int nargs, int nresults, lua_KContext, lua_KFunction) {
+inline void lua_callk(lua_State *L, int nargs, int nresults, lua_KContext, lua_KFunction) {
     // should probably warn the user of Lua 5.1 that continuation isn't supported...
     lua_call(L, nargs, nresults);
 }
-int lua_pcallk(lua_State *L, int nargs, int nresults, int errfunc, lua_KContext, lua_KFunction) {
+inline int lua_pcallk(lua_State *L, int nargs, int nresults, int errfunc, lua_KContext, lua_KFunction) {
     // should probably warn the user of Lua 5.1 that continuation isn't supported...
     return lua_pcall(L, nargs, nresults, errfunc);
 }


### PR DESCRIPTION
This was causing my builds to break due to multiply defined symbols.

I actually do not know why this works now. I checked all of the include guards, and they're correct. 