### PR TITLE
Removed stray <feff> byte order mark

### DIFF
--- a/sol/function.hpp
+++ b/sol/function.hpp
@@ -1,4 +1,4 @@
-﻿// The MIT License (MIT)
+// The MIT License (MIT)
 
 // Copyright (c) 2013-2016 Rapptz, ThePhD and contributors
 

--- a/sol/function_types_core.hpp
+++ b/sol/function_types_core.hpp
@@ -1,4 +1,4 @@
-﻿// The MIT License (MIT)
+// The MIT License (MIT)
 
 // Copyright (c) 2013-2016 Rapptz, ThePhD and contributors
 

--- a/sol/inheritance.hpp
+++ b/sol/inheritance.hpp
@@ -1,4 +1,4 @@
-﻿// The MIT License (MIT)
+// The MIT License (MIT)
 
 // Copyright (c) 2013-2016 Rapptz, ThePhD and contributors
 


### PR DESCRIPTION
This fixes compiling with clang on msys2. I believe you saved these files as UTF16 once or something and these byte order marks were added by an editor.
The PR leads to the line "﻿// The MIT License (MIT)" to no longer be present in the single-header sol.hpp at 3 occasions, but I think they were there by mistake anyway and should've been stripped by the python script, but didn't, because of the BOM. So this actually fixes that as well.