### PR TITLE
Added table::get_with_default method

### DIFF
--- a/sol/table_core.hpp
+++ b/sol/table_core.hpp
@@ -140,6 +140,18 @@ public:
         return tuple_get( types<Ret...>( ), std::index_sequence_for<Ret...>( ), std::forward_as_tuple(std::forward<Keys>(keys)...));
     }
 
+    template<typename Ret, typename Key>
+    Ret get_with_default(Key key, Ret _default) const {
+
+      sol::optional<Ret> option = operator[](key);
+      if( option ){
+        return option.value();
+      }
+      else {
+        return _default;
+      }
+    }
+
     template <typename T, typename... Keys>
     decltype(auto) traverse_get( Keys&&... keys ) const {
         auto pp = stack::push_pop<is_global<Keys...>::value>(*this);

--- a/tests.cpp
+++ b/tests.cpp
@@ -505,6 +505,23 @@ TEST_CASE("tables/variables", "Check if tables and variables work as intended") 
     REQUIRE_NOTHROW(lua.script("assert(os.name == \"windows\")"));
 }
 
+TEST_CASE("simple/get_default", "Test that table::get_default work corretly") {
+  sol::state lua;
+
+  auto bob_table = lua.create_table("bob");
+  int is_set=0;
+  int is_not_set=0;
+  bob_table.set("is_set",42);
+
+  is_set = bob_table.get_with_default("is_set",3);
+  is_not_set = bob_table.get_with_default("is_not_set",22);
+
+  REQUIRE(is_set == 42);
+  REQUIRE(is_not_set == 22);
+}
+
+
+
 TEST_CASE("tables/create", "Check if creating a table is kosher") {
     sol::state lua;
     lua["testtable"] = sol::table::create(lua.lua_state(), 0, 0, "Woof", "Bark", 1, 2, 3, 4);


### PR DESCRIPTION
There is now a sol::table::get_with_default method that takes 2
arguments, one being the key to search on, the other being the default.
If the key does not have a value in the table the default value is
returned. I expect this to be particularly useful when using lua to optionally
override default values in c++ code. 