### PR TITLE
Fixed a small typo in the usertype documentation.

### DIFF
--- a/docs/source/api/usertype.rst
+++ b/docs/source/api/usertype.rst
@@ -83,7 +83,7 @@ Note that here, because the C++ class is default-constructible, it will automati
 	-- note the ":" that is there: this is mandatory for member function calls
 	-- ":" means "pass self" in Lua
 	local success = fwoosh:shoot()
-	local is_dead = fwoosh:hit(20)
+	local is_dead = fwoosh:hurt(20)
 	-- check if it works
 	print(is_dead) -- the ship is not dead at this point
 	print(fwoosh.life .. "life left") -- 80 life left


### PR DESCRIPTION
This isn't anything major, I just didn't want to open another issue about it so I can save you some time.

There was a small typo on the usertype documentation, where a function was defined as `hurt` but was called as `hit` instead.