### PR TITLE
Use Boost Optional if USE_BOOST is defined

### DIFF
--- a/sol/optional.hpp
+++ b/sol/optional.hpp
@@ -24,6 +24,8 @@
 
 #if __cplusplus > 201402L
 #include <optional>
+#elif defined(SOL_USE_BOOST)
+#include <boost/optional.hpp>
 #else
 #include "../Optional/optional.hpp"
 #endif // C++ 14
@@ -35,6 +37,11 @@ template <typename T>
 using optional = sol::optional<T>;
 using nullopt_t = std::nullopt_t;
 constexpr nullopt_t nullopt = std::nullopt;
+#elif defined(SOL_USE_BOOST)
+template <typename T>
+using optional = boost::optional<T>;
+using nullopt_t = boost::none_t;
+const nullopt_t nullopt = boost::none;
 #else
 #endif // C++ 14
 }


### PR DESCRIPTION
Usecase: Your project (where you plan to to use sol2 for interfacing with lua) already uses Boost as dependency, your compiler doesn't come with <optional> yet and you want to minimize further dependencies.

That means that with that change and defining `USE_BOOST` one doesn't need to pull the solarized optional repository anymore.