### PR TITLE
Use nullptr when converting to std::function if value is nil

### DIFF
--- a/sol/function.hpp
+++ b/sol/function.hpp
@@ -105,6 +105,9 @@ namespace sol {
 
 			template<typename... Args, typename... Ret>
 			static std::function<Signature> get_std_func(types<Ret...>, types<Args...>, lua_State* L, int index = -1) {
+				if (lua_isnil(L, index) || lua_isnone(L, index)) {
+					return nullptr;
+				}
 				sol::function f(L, index);
 				auto fx = [f, L, index](Args&&... args) -> meta::return_type_t<Ret...> {
 					return f.call<Ret...>(std::forward<Args>(args)...);
@@ -114,6 +117,9 @@ namespace sol {
 
 			template<typename... FxArgs>
 			static std::function<Signature> get_std_func(types<void>, types<FxArgs...>, lua_State* L, int index = -1) {
+				if (lua_isnil(L, index) || lua_isnone(L, index)) {
+					return nullptr;
+				}
 				sol::function f(L, index);
 				auto fx = [f, L, index](FxArgs&&... args) -> void {
 					f(std::forward<FxArgs>(args)...);


### PR DESCRIPTION
Hi, I've just started to use sol in my own project. I ran into this problem when converting a lua function to std::function, there was no way to tell if the function is nil in C++ code without using sol::function, and the program would crash when the function is called.