### PR TITLE
Support for Lua 5.3 UTF8 Library

### DIFF
--- a/sol/state_view.hpp
+++ b/sol/state_view.hpp
@@ -41,6 +41,7 @@ namespace sol {
 		io,
 		ffi,
 		jit,
+		utf8,
 		count
 	};
 
@@ -147,6 +148,12 @@ namespace sol {
 					luaL_requiref(L, "coroutine", luaopen_coroutine, 1);
 					lua_pop(L, 1);
 #endif // Lua 5.2+ only
+					break;
+				case lib:utf8:
+#if SOL_LUA_VERSION > 502
+					luaL_requiref(L, "utf8", luaopen_utf8, 1);
+					lua_pop(L, 1);
+#endif // Lua 5.3+ only
 					break;
 #endif // Not LuaJIT
 				case lib::string:

--- a/sol/state_view.hpp
+++ b/sol/state_view.hpp
@@ -149,12 +149,6 @@ namespace sol {
 					lua_pop(L, 1);
 #endif // Lua 5.2+ only
 					break;
-				case lib:utf8:
-#if SOL_LUA_VERSION > 502
-					luaL_requiref(L, "utf8", luaopen_utf8, 1);
-					lua_pop(L, 1);
-#endif // Lua 5.3+ only
-					break;
 #endif // Not LuaJIT
 				case lib::string:
 					luaL_requiref(L, "string", luaopen_string, 1);
@@ -189,6 +183,12 @@ namespace sol {
 				case lib::debug:
 					luaL_requiref(L, "debug", luaopen_debug, 1);
 					lua_pop(L, 1);
+					break;
+				case lib:utf8:
+#if SOL_LUA_VERSION > 502 && !defined(SOL_LUAJIT)
+					luaL_requiref(L, "utf8", luaopen_utf8, 1);
+					lua_pop(L, 1);
+#endif // Lua 5.3+ only
 					break;
 				case lib::ffi:
 #ifdef SOL_LUAJIT

--- a/sol/state_view.hpp
+++ b/sol/state_view.hpp
@@ -184,7 +184,7 @@ namespace sol {
 					luaL_requiref(L, "debug", luaopen_debug, 1);
 					lua_pop(L, 1);
 					break;
-				case lib:utf8:
+				case lib::utf8:
 #if SOL_LUA_VERSION > 502 && !defined(SOL_LUAJIT)
 					luaL_requiref(L, "utf8", luaopen_utf8, 1);
 					lua_pop(L, 1);


### PR DESCRIPTION
This patch adds support for the new Lua 5.3 library `utf8`.
One can now enable it like any other library using `sol::state_view::open_libraries(...)`:

```cpp
state.open_libraries(sol::lib::utf8);
```