### PR TITLE
Fix 'expected .. received ..' message for function arguments

### DIFF
--- a/single/sol/sol.hpp
+++ b/single/sol/sol.hpp
@@ -4607,7 +4607,7 @@ namespace sol {
 					return true;
 				}
 				if (t != type::userdata && t != type::table) {
-					handler(L, index, t, type::function);
+					handler(L, index, type::function, t);
 					return false;
 				}
 				// Do advanced check for call-style userdata?
@@ -4615,13 +4615,13 @@ namespace sol {
 				lua_getmetatable(L, index);
 				if (lua_isnoneornil(L, -1)) {
 					lua_pop(L, 1);
-					handler(L, index, t, type::function);
+					handler(L, index, type::function, t);
 					return false;
 				}
 				lua_getfield(L, -1, &callkey[0]);
 				if (lua_isnoneornil(L, -1)) {
 					lua_pop(L, 2);
-					handler(L, index, t, type::function);
+					handler(L, index, type::function, t);
 					return false;
 				}
 				// has call, is definitely a function
@@ -4640,7 +4640,7 @@ namespace sol {
 					return true;
 				}
 				if (t != type::userdata) {
-					handler(L, index, t, type::function);
+					handler(L, index, type::function, t);
 					return false;
 				}
 				return true;

--- a/sol/stack_check.hpp
+++ b/sol/stack_check.hpp
@@ -194,7 +194,7 @@ namespace sol {
 					return true;
 				}
 				if (t != type::userdata && t != type::table) {
-					handler(L, index, t, type::function);
+					handler(L, index, type::function, t);
 					return false;
 				}
 				// Do advanced check for call-style userdata?
@@ -202,13 +202,13 @@ namespace sol {
 				lua_getmetatable(L, index);
 				if (lua_isnoneornil(L, -1)) {
 					lua_pop(L, 1);
-					handler(L, index, t, type::function);
+					handler(L, index, type::function, t);
 					return false;
 				}
 				lua_getfield(L, -1, &callkey[0]);
 				if (lua_isnoneornil(L, -1)) {
 					lua_pop(L, 2);
-					handler(L, index, t, type::function);
+					handler(L, index, type::function, t);
 					return false;
 				}
 				// has call, is definitely a function
@@ -227,7 +227,7 @@ namespace sol {
 					return true;
 				}
 				if (t != type::userdata) {
-					handler(L, index, t, type::function);
+					handler(L, index, type::function, t);
 					return false;
 				}
 				return true;


### PR DESCRIPTION
For some reason, whenever type::function was expected, the argument order given to the checker is the other way around. This produces messages such as:
> expected number, received function

when executing process_callback(100), whereas process_callback takes a sol::function as argument.

 I'm not sure whether this is the case for any other types, but I didn't find any cases when I had a quick look.

PS I'm absolutely loving this library so far!