### PR TITLE
Fix OSX + Luajit

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -110,6 +110,7 @@ elif 'darwin' in sys.platform:
         # luajit
         lua_incl = 'luajit-2.0'
         lua_lib = 'luajit'
+        ldflags.extend(['-pagezero_size 10000', '-image_base 100000000'])
     else:
         raise Exception('Unknown lua_version={}' % lua_version)
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -106,10 +106,10 @@ elif 'darwin' in sys.platform:
         # Using normal lua
         lua_incl = lua_version[:-1] + '.' + lua_version[-1]
         lua_lib = lua_version[:-2] + '.' +  lua_version[-2] + '.' + lua_version[-1]
-    elif re.match(r'luajit5[1-3]', lua_version):
+    elif re.match(r'luajit', lua_version):
         # luajit
         lua_incl = 'luajit-2.0'
-        lua_lib = lua_version[:-2] + '-' + lua_version[-2] + '.' + lua_version[-1]
+        lua_lib = 'luajit'
     else:
         raise Exception('Unknown lua_version={}' % lua_version)
 


### PR DESCRIPTION
First commit gives you a build.ninja that will actually link with luajit (it also means you specify luajit not luajit52 which makes more sense IMO).

Second commit makes the tests pass. Relevant to #184 if you check the luajit [installation guide](http://luajit.org/install.html) you'll find this:

```
If you're building a 64 bit application on OSX which links directly or indirectly against LuaJIT, 
you need to link your main executable with these flags:

     -pagezero_size 10000 -image_base 100000000
``` 
There really isn't an explanation for why this magic is necessary- but without it, your application _will_ crash. If you use `-fsanitize=address` you're app becomes explosive.

