### PR TITLE
LuaJIT C++ Exception Full Interoperability Support & Missing ';' when SOL_NO_EXCEPTIONS is defined

### DIFF
--- a/docs/source/exceptions.rst
+++ b/docs/source/exceptions.rst
@@ -45,9 +45,16 @@ If there is a place where a throw statement is called or a try/catch is used and
 LuaJIT and exceptions
 ---------------------
 
-It is important to note that a popular 5.1 distribution of Lua, LuaJIT, has some serious `caveats regarding exceptions`_. LuaJIT's exception promises are flaky at best on x64 (64-bit) platforms, and entirely terrible on non-x64 (32-bit, ARM, etc.) platorms. The trampolines we have in place for all functions bound through conventional means in Sol will catch exceptions and turn them into Lua errors so that LuaJIT remainds unperturbed, but if you link up a C function directly yourself and throw, chances are you might have screwed the pooch.
+It is important to note that a popular 5.1 distribution of Lua, LuaJIT, has some serious `caveats regarding exceptions`_. LuaJIT's exception promises are flaky at best on x64 (64-bit) platforms, and entirely terrible on non-x64 (32-bit, ARM, etc.) platforms. The trampolines we have in place for all functions bound through conventional means in Sol will catch exceptions and turn them into Lua errors so that LuaJIT remainds unperturbed, but if you link up a C function directly yourself and throw, chances are you might have screwed the pooch.
 
 Testing in `this closed issue`_ that it doesn't play nice on 64-bit Linux in many cases either, especially when it hits an error internal to the interpreter (and does not go through Sol). We do have tests, however, that compile for our continuous integration check-ins that check this functionality across several compilers and platforms to keep you protected and given hard, strong guarantees for what happens if you throw in a function bound by Sol. If you stray outside the realm of Sol's protection, however... Good luck.
+
+.. _LuaJIT C++ Exception Full Interoperability
+
+LuaJIT C++ Exception Full Interoperability
+------------------------------------------
+
+If you are using a platform and compiler that has full c++ exception interoperability (http://luajit.org/extensions.html#exceptions), define ``SOL_LUAJIT_FULL_INTEROPERABILITY``. This will prevent sol from catching (...) errors - in platforms & compilers than have full c++ exception interoperability Lua errors can be caught with catch (...) in C++ - in these cases sol inaccurately prevents Lua errors from being propagated correctly.
 
 .. _issue: https://github.com/ThePhD/sol2/issues/
 .. _at_panic: http://www.Lua.org/manual/5.3/manual.html#4.6

--- a/single/sol/sol.hpp
+++ b/single/sol/sol.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2016-11-09 12:45:41.921113 UTC
-// This header was generated with sol v2.15.0 (revision 4116db8)
+// Generated 2016-11-13 06:01:48.356322 UTC
+// This header was generated with sol v2.15.0 (revision 951b821)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_HPP
@@ -770,7 +770,7 @@ namespace sol {
 
 #include <lua.hpp>
 
-#if defined(_WIN32) || defined(_MSC_VER)  || defined(__MINGW32__)
+#if defined(_WIN32) || defined(_MSC_VER)
 #ifndef SOL_CODECVT_SUPPORT
 #define SOL_CODECVT_SUPPORT 1
 #endif // sol codecvt support
@@ -779,7 +779,7 @@ namespace sol {
 #ifndef SOL_CODECVT_SUPPORT
 #define SOL_CODECVT_SUPPORT 1
 #endif // codecvt support
-#endif // g++ 5.x.x
+#endif // g++ 5.x.x (MinGW too)
 #else
 #endif // Windows/VC++ vs. g++ vs Others
 
@@ -2411,7 +2411,7 @@ namespace sol {
 #ifdef SOL_NO_EXCEPTIONS
 				// we can abort here
 				// but the others are constexpr, so we can't...
-				: (std::abort(), *(T*)nullptr)
+				: (std::abort(), *(T*)nullptr);
 #else
 				: (throw bad_optional_access("bad optional access"), contained_val());
 #endif
@@ -3000,9 +3000,11 @@ namespace sol {
 			catch (const std::exception& e) {
 				lua_pushstring(L, e.what());
 			}
+#ifndef SOL_LUAJIT_FULL_INTEROPERABILITY
 			catch (...) {
 				lua_pushstring(L, "caught (...) exception");
 			}
+#endif
 			return lua_error(L);
 		}
 
@@ -3017,9 +3019,11 @@ namespace sol {
 			catch (const std::exception& e) {
 				lua_pushstring(L, e.what());
 			}
+#ifndef SOL_LUAJIT_FULL_INTEROPERABILITY
 			catch (...) {
 				lua_pushstring(L, "caught (...) exception");
 			}
+#endif
 			return lua_error(L);
 		}
 

--- a/sol/optional_implementation.hpp
+++ b/sol/optional_implementation.hpp
@@ -636,7 +636,7 @@ namespace sol {
 #ifdef SOL_NO_EXCEPTIONS
 				// we can abort here
 				// but the others are constexpr, so we can't...
-				: (std::abort(), *(T*)nullptr)
+				: (std::abort(), *(T*)nullptr);
 #else
 				: (throw bad_optional_access("bad optional access"), contained_val());
 #endif

--- a/sol/types.hpp
+++ b/sol/types.hpp
@@ -57,9 +57,11 @@ namespace sol {
 			catch (const std::exception& e) {
 				lua_pushstring(L, e.what());
 			}
+#ifndef SOL_LUAJIT_FULL_INTEROPERABILITY
 			catch (...) {
 				lua_pushstring(L, "caught (...) exception");
 			}
+#endif
 			return lua_error(L);
 		}
 
@@ -74,9 +76,11 @@ namespace sol {
 			catch (const std::exception& e) {
 				lua_pushstring(L, e.what());
 			}
+#ifndef SOL_LUAJIT_FULL_INTEROPERABILITY
 			catch (...) {
 				lua_pushstring(L, "caught (...) exception");
 			}
+#endif
 			return lua_error(L);
 		}
 


### PR DESCRIPTION
1. Missing ';' when SOL_NO_EXCEPTIONS is defined
2. If you are using a platform and compiler that has full c++ exception interoperability (http://luajit.org/extensions.html#exceptions), define SOL_LUAJIT_FULL_INTEROPERABILITY. This will prevent sol from catching (...) errors - in platforms & compilers than have full c++ exception interoperability Lua errors can be caught with catch (...) in C++ - in these cases sol inaccurately prevents Lua errors from being propagated correctly.