### PR TITLE
fix thread_status::dead value for luajit

### DIFF
--- a/sol/types.hpp
+++ b/sol/types.hpp
@@ -343,7 +343,7 @@ namespace sol {
 		memory = LUA_ERRMEM,
 		gc = LUA_ERRGCMM,
 		handler = LUA_ERRERR,
-		dead,
+		dead = -1,
 	};
 
 	enum class load_status : int {


### PR DESCRIPTION
sol::thread_status::dead has an incorrect value when using sol with luajit. it occurs because luajit has no LUA_ERRGCMM and sol [adds its own](https://github.com/ThePhD/sol2/blob/develop/sol/compatibility/5.1.0.h#L51).

why
```cpp
enum class thread_status : int {
  ok = LUA_OK, // = 0
  yielded = LUA_YIELD, // = 1
  runtime = LUA_ERRRUN, // = 2
  memory = LUA_ERRMEM, // = 4 (it's ok)
  gc = LUA_ERRGCMM, // = 6
  handler = LUA_ERRERR, // = 5
  dead, // = 6! same value as thread_status::gc
};
```
i decided just assign thread_status::dead const value `-1` - it shouldn't cause any incompatibilities (i guess). anyway i don't insist this is the right solution so feel free to edit/discard the PR and fix this bug the right way.