### PR TITLE
Correct the LuaJIT 2.1.0 condition

### DIFF
--- a/sol/compatibility/5.1.0.h
+++ b/sol/compatibility/5.1.0.h
@@ -158,7 +158,7 @@ inline const char* kepler_lua_compat_get_string(lua_State* L, void* ud, size_t* 
     return ls->s;
 }
 
-#if !defined(SOL_LUAJIT) || ((SOL_LUAJIT_VERSION - 20100) <= 0)
+#if !defined(SOL_LUAJIT) || (SOL_LUAJIT_VERSION < 20100)
 // Luajit 2.1.0 has this function already
 
 inline int luaL_loadbufferx(lua_State* L, const char* buff, size_t size, const char* name, const char*) {


### PR DESCRIPTION
Should be LUAJIT_VERSION < 20100, not LUAJIT_VERSION <= 20100. Otherwise, it generates linker errors when LUAJIT_VERSION == 20100.

I also thought that the condition is clearer if written in the form `if (x < y)` rather than `if ((x-y) < 0)`

Tested and builds with no linker errors for LuaJIT 2.0.4 and 2.1.0 beta 2.