### PR TITLE
Fixed typo: luaxlib.h -> lauxlib.h

### DIFF
--- a/sol/compatibility/version.hpp
+++ b/sol/compatibility/version.hpp
@@ -25,7 +25,7 @@
 #ifdef SOL_USING_CXX_LUA
 #include <lua.h>
 #include <lualib.h>
-#include <luaxlib.h>
+#include <lauxlib.h>
 #else
 #include <lua.hpp>
 #endif // C++-compiler Lua


### PR DESCRIPTION
This is totally nothing, but using 'SOL_USING_CXX_LUA' produced compile error.
Thank you for the great library!