### PR TITLE
Work around clang-cl compilation issue.

### DIFF
--- a/single/sol/sol.hpp
+++ b/single/sol/sol.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2017-01-10 04:24:27.805667 UTC
-// This header was generated with sol v2.15.7 (revision 490194f)
+// Generated 2017-01-26 01:38:28.868453 UTC
+// This header was generated with sol v2.15.7 (revision 5b12924)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_HPP
@@ -793,7 +793,7 @@ namespace sol {
 #ifdef SOL_USING_CXX_LUA
 #include <lua.h>
 #include <lualib.h>
-#include <luaxlib.h>
+#include <lauxlib.h>
 #else
 #include <lua.hpp>
 #endif // C++-compiler Lua
@@ -4128,7 +4128,7 @@ namespace sol {
 		void set_extra(std::true_type, std::index_sequence<I...>, T&& target) {
 			using std::get;
 			(void)detail::swallow{ 0,
-				(get<I>(*this) = get<I>(types<Tn...>(), target), 0)...
+				(get<I>(static_cast<base_t&>(*this)) = get<I>(types<Tn...>(), target), 0)...
 				, 0 };
 		}
 
@@ -4136,7 +4136,7 @@ namespace sol {
 		void set_extra(std::false_type, std::index_sequence<I...>, T&& target) {
 			using std::get;
 			(void)detail::swallow{ 0,
-				(get<I>(*this) = get<I>(target), 0)...
+				(get<I>(static_cast<base_t&>(*this)) = get<I>(target), 0)...
 				, 0 };
 		}
 

--- a/sol/tie.hpp
+++ b/sol/tie.hpp
@@ -60,7 +60,7 @@ namespace sol {
 		void set_extra(std::true_type, std::index_sequence<I...>, T&& target) {
 			using std::get;
 			(void)detail::swallow{ 0,
-				(get<I>(*this) = get<I>(types<Tn...>(), target), 0)...
+				(get<I>(static_cast<base_t&>(*this)) = get<I>(types<Tn...>(), target), 0)...
 				, 0 };
 		}
 
@@ -68,7 +68,7 @@ namespace sol {
 		void set_extra(std::false_type, std::index_sequence<I...>, T&& target) {
 			using std::get;
 			(void)detail::swallow{ 0,
-				(get<I>(*this) = get<I>(target), 0)...
+				(get<I>(static_cast<base_t&>(*this)) = get<I>(target), 0)...
 				, 0 };
 		}
 


### PR DESCRIPTION
For whatever reason clang-cl doesn't like the use of std::get on tie_t. (Then the tests segfault once you can build them, but that's a separate issue.)

Using latest clang-cl with latest MSVC.

```
clang version 4.0.0 (trunk)
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Tools\LLVM-4.0.0-r291453-win64\bin
```

```
Microsoft (R) C/C++ Optimizing Compiler Version 19.00.24215.1 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

Compiler Passes:
 C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\amd64\cl.exe:        Version 19.00.24215.1
 C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\amd64\c1.dll:        Version 19.00.24215.1
 C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\amd64\c1xx.dll:      Version 19.00.24215.1
 C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\amd64\c2.dll:        Version 19.00.24215.1
 C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\amd64\link.exe:      Version 14.00.24215.1
 C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\amd64\mspdb140.dll:  Version 14.00.24210.0
 C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\amd64\1033\clui.dll: Version 19.00.24215.1
```
Partial error output (there's a lot of it, I tried to strip out most of the junk):
```
In file included from C:\Code\sol2\sol2\test_customizations.cpp:4:
C:\Code\sol2\sol2\single\sol\sol.hpp(4127,6):  error: no matching function for call to 'get'
                                (get<I>(*this) = get<I>(types<Tn...>(), target), 0)...
                                 ^~~~~~
C:\Code\sol2\sol2\single\sol\sol.hpp(4120,4):  note: in instantiation of function template specialization 'sol::tie_t<two_things, double>::set_extra<0, 1, sol::function_result>' requested here
                        set_extra(detail::is_speshul<meta::unqualified_t<T>>(), indices(), std::forward<T>(target));
                        ^
C:\Code\sol2\sol2\single\sol\sol.hpp(4145,4):  note: in instantiation of function template specialization 'sol::tie_t<two_things, double>::set<sol::function_result>' requested here
                        set(tieable(), std::forward<T>(value));
                        ^
C:\Code\sol2\sol2\test_customizations.cpp(79,25):  note: in instantiation of function template specialization 'sol::tie_t<two_things, double>::operator=<sol::function_result>' requested here
        sol::tie( thingsg, d ) = g(two_things{ 25, false }, 2, 34.0);
```

[SNIP]

```
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE\tuple(882,3):  note: candidate template ignored: failed template argument deduction
                get(tuple<_Types...>& _Tuple) _NOEXCEPT
                ^
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE\tuple(892,3):  note: candidate template ignored: failed template argument deduction
                get(const tuple<_Types...>& _Tuple) _NOEXCEPT
                ^
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE\tuple(902,3):  note: candidate template ignored: failed template argument deduction
                get(tuple<_Types...>&& _Tuple) _NOEXCEPT
                ^
```
