### PR TITLE
Fix building tests with Catch v1.7.2.

### DIFF
--- a/test_containers.cpp
+++ b/test_containers.cpp
@@ -155,20 +155,20 @@ TEST_CASE("containers/basic-serialization", "make sure containers are turned int
 	lua.open_libraries();
 	lua.set("b", woof{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30 });
 	REQUIRE_NOTHROW(
-	lua.script("for k = 1, #b do assert(k == b[k]) end");
+	lua.script("for k = 1, #b do assert(k == b[k]) end")
 	);
 	woof w{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30 };
 	lua.set("b", w);
 	REQUIRE_NOTHROW(
-		lua.script("for k = 1, #b do assert(k == b[k]) end");
+		lua.script("for k = 1, #b do assert(k == b[k]) end")
 	);
 	lua.set("b", &w);
 	REQUIRE_NOTHROW(
-		lua.script("for k = 1, #b do assert(k == b[k]) end");
+		lua.script("for k = 1, #b do assert(k == b[k]) end")
 	);
 	lua.set("b", std::ref(w));
 	REQUIRE_NOTHROW(
-		lua.script("for k = 1, #b do assert(k == b[k]) end");
+		lua.script("for k = 1, #b do assert(k == b[k]) end")
 	);
 }
 
@@ -191,20 +191,20 @@ TEST_CASE("containers/table-serialization", "ensure types can be serialized as t
 	lua.open_libraries();
 	lua.set("b", sol::as_table(woof{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30 }));
 	REQUIRE_NOTHROW(
-		lua.script("for k, v in ipairs(b) do assert(k == v) end");
+		lua.script("for k, v in ipairs(b) do assert(k == v) end")
 	);
 	woof w{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30 };
 	lua.set("b", sol::as_table(w));
 	REQUIRE_NOTHROW(
-	lua.script("for k, v in ipairs(b) do assert(k == v) end");
+	lua.script("for k, v in ipairs(b) do assert(k == v) end")
 	);
 	lua.set("b", sol::as_table(&w));
 	REQUIRE_NOTHROW(
-	lua.script("for k, v in ipairs(b) do assert(k == v) end");
+	lua.script("for k, v in ipairs(b) do assert(k == v) end")
 	);
 	lua.set("b", sol::as_table(std::ref(w)));
 	REQUIRE_NOTHROW(
-	lua.script("for k, v in ipairs(b) do assert(k == v) end");
+	lua.script("for k, v in ipairs(b) do assert(k == v) end")
 	);
 }
 
@@ -237,10 +237,10 @@ func = function(vecs)
 end
 )");
 
-	REQUIRE_NOTHROW({
+	REQUIRE_NOTHROW([&]{
 		lua["func"](foo);
 		lua["func"](bar);
-	});
+	}());
 }
 
 TEST_CASE("containers/arbitrary-creation", "userdata and tables should be usable from standard containers") {

--- a/test_functions.cpp
+++ b/test_functions.cpp
@@ -205,7 +205,7 @@ end )");
 	REQUIRE_FALSE((bool)testn);
 	REQUIRE(testv.value() == 29);
 	sol::optional<thing> v = lua_bark(sol::optional<thing>(thing{ 29 }));
-	REQUIRE_NOTHROW(sol::nil_t n = lua_bark(sol::nullopt));
+	REQUIRE_NOTHROW([&]{sol::nil_t n = lua_bark(sol::nullopt);}());
 	REQUIRE(v->v == 29);
 }
 

--- a/test_operators.cpp
+++ b/test_operators.cpp
@@ -46,38 +46,38 @@ TEST_CASE("operators/default", "test that generic equality operators and all sor
 	lua["v3"] = &v3;
 
 	// Can only compare identity here
-	REQUIRE_NOTHROW({
+	REQUIRE_NOTHROW([&]{
 		lua.script("assert(t1 == t1)");
 		lua.script("assert(t2 == t2)");
 		lua.script("assert(t3 == t3)");
-	});
-	REQUIRE_NOTHROW({
+	}());
+	REQUIRE_NOTHROW([&]{
 		lua.script("assert(t1 == t2)");
 		lua.script("assert(not (t1 == t3))");
 		lua.script("assert(not (t2 == t3))");
-	});
+	}());
 	// Object should compare equal to themselves
 	// (and not invoke operator==; pointer test should be sufficient)
-	REQUIRE_NOTHROW({
+	REQUIRE_NOTHROW([&]{
 		lua.script("assert(u1 == u1)");
 		lua.script("assert(u2 == u2)");
 		lua.script("assert(u3 == u3)");
-	});
-	REQUIRE_NOTHROW({
+	}());
+	REQUIRE_NOTHROW([&]{
 		lua.script("assert(not (u1 == u2))");
 		lua.script("assert(u1 == u3)");
 		lua.script("assert(not (u2 == u3))");
-	});
+	}());
 	// Object should compare equal to themselves
 	// (and not invoke operator==; pointer test should be sufficient)
-	REQUIRE_NOTHROW({
+	REQUIRE_NOTHROW([&]{
 		lua.script("assert(v1 == v1)");
 		lua.script("assert(v2 == v2)");
 		lua.script("assert(v3 == v3)");
-	});
-	REQUIRE_NOTHROW({
+	}());
+	REQUIRE_NOTHROW([&]{
 		lua.script("assert(not (v1 == v2))");
 		lua.script("assert(v1 == v3)");
 		lua.script("assert(not (v2 == v3))");
-	});
+	}());
 }

--- a/test_overflow.cpp
+++ b/test_overflow.cpp
@@ -11,22 +11,22 @@ TEST_CASE("issues/stack-overflow", "make sure various operations repeated don't 
 
 	sol::function f = lua["lua_function"];
 	std::string teststring = "testtext";
-	REQUIRE_NOTHROW(
+	REQUIRE_NOTHROW([&]{
 		for (int i = 0; i < 1000000; ++i) {
 			std::string result = f(teststring);
 			if (result != teststring) throw std::logic_error("RIP");
 		}
-	);
+	}());
 	sol::table t = lua["t"];
 	int expected = 20;
-	REQUIRE_NOTHROW(
+	REQUIRE_NOTHROW([&]{
 		for (int i = 0; i < 1000000; ++i) {
 			int result = t[0];
 			t.size();
 			if (result != expected)
 				throw std::logic_error("RIP");
 		}
-	);
+	}());
 }
 
 

--- a/test_simple_usertypes.cpp
+++ b/test_simple_usertypes.cpp
@@ -455,11 +455,11 @@ TEST_CASE("usertype/simple-table-append", "Ensure that appending to the meta tab
 	lua.set("a", &a);
 	lua.set("pa", &a);
 	lua.set("ua", std::make_unique<A>());
-	REQUIRE_NOTHROW(
+	REQUIRE_NOTHROW([&]{
 		lua.script("assert(a:func() == 5000)");
 		lua.script("assert(pa:func() == 5000)");
 		lua.script("assert(ua:func() == 5000)");
-	);
+	}());
 }
 
 TEST_CASE("usertype/simple-class-propogation", "make sure methods and variables from base classes work properly in SAFE_USERTYPE mode") {

--- a/test_usertypes.cpp
+++ b/test_usertypes.cpp
@@ -1202,7 +1202,7 @@ TEST_CASE("usertype/protect", "users should be allowed to manually protect a fun
 		lua.script(R"__(
 pm = protect_me.new()
 value = pcall(pm.gen,pm)
-)__");
+)__")
 	);
 	bool value = lua["value"];
 	REQUIRE_FALSE(value);
@@ -1402,13 +1402,13 @@ TEST_CASE("usertype/unique_usertype-check", "make sure unique usertypes don't ge
 )");
 
 	sol::function my_func = lua["my_func"];
-	REQUIRE_NOTHROW({
+	REQUIRE_NOTHROW([&]{
 	auto ent = std::make_shared<Entity>();
 	my_func(ent);
 	Entity ent2;
 	my_func(ent2);
 	my_func(std::make_shared<Entity>());
-	});
+	}());
 }
 
 TEST_CASE("usertype/abstract-base-class", "Ensure that abstract base classes and such can be registered") {	

--- a/tests.cpp
+++ b/tests.cpp
@@ -632,13 +632,13 @@ TEST_CASE("optional/left-out-args", "Make sure arguments can be left out of opti
 
 	// sol::optional needs an argument no matter what?
 	lua.set_function("func_opt_ret_bool", func_opt_ret_bool);
-	REQUIRE_NOTHROW(
+	REQUIRE_NOTHROW([&]{
 	lua.script(R"(
         func_opt_ret_bool(42)
         func_opt_ret_bool()
         print('ok')
         )");
-	);
+	}());
 }
 
 TEST_CASE("pusher/constness", "Make sure more types can handle being const and junk") {


### PR DESCRIPTION
From the Catch docs:
Please note that the THROW family of assertions expects to be passed a single
expression, not a statement or series of statements. If you want to check a
more complicated sequence of operations, you can use a C++11 lambda function.

https://github.com/philsquared/Catch/blob/master/docs/assertions.md

In current versions of Catch violating this causes a build error.