### PR TITLE
"error" has been made accessible in the Lua state

### DIFF
--- a/examples/protected_functions.cpp
+++ b/examples/protected_functions.cpp
@@ -7,6 +7,7 @@ int main() {
 	std::cout << "=== protected_functions example ===" << std::endl;
 
 	sol::state lua;
+	lua.open_libraries(sol::lib::base);
 
 	// A complicated function which can error out
 	// We define both in terms of Lua code


### PR DESCRIPTION
We need to expose `error()` in Lua in order to let it call the error handler function. However, for that the base library needs to be available in the Lua state.
 
Without this fix the output of the program is
`call failed, sol::error::what() is Handled this message: [string "..."]:7: attempt to call a nil value (global 'error')`
while it's supposed to be
`call failed, sol::error::what() is Handled this message: [string "..."]:7: negative number detected`