### PR TITLE
Add :find to containers to make std::[unordered_]set more useful Lua-side

### DIFF
--- a/docs/source/api/containers.rst
+++ b/docs/source/api/containers.rst
@@ -76,7 +76,7 @@ Based on the type pushed, a few additional functions are added as "member functi
 * ``my_container:clear()``: This will call the underlying containers ``clear`` function.
 * ``my_container:add( key, value )`` or ``my_container:add( value )``: this will add to the end of the container, or if it is an associative or ordered container, simply put in an expected key-value pair into it.
 * ``my_contaner:insert( where, value )`` or ``my_contaner:insert( key, value )``: similar to add, but it only takes two arguments. In the case of ``std::vector`` and the like, the first argument is a ``where`` integer index. The second argument is the value. For associative containers, a key and value argument are expected.
-
+* ``my_container:find( value )``: This will call the underlying containers ``find`` function if it exists, or in case of associative containers, it will work just like an index call. This is meant to give a fast membership check for ``std::set`` and ``std::unordered_set`` containers.
 
 .. _container-detection:
 

--- a/test_containers.cpp
+++ b/test_containers.cpp
@@ -289,6 +289,11 @@ end
 function i (x)
 	x:clear()
 end
+
+function sf (x,v)
+	return x:find(v)
+end
+
 )");
 
 	// Have the function we 
@@ -296,6 +301,7 @@ end
 	sol::function g = lua["g"];
 	sol::function h = lua["h"];
 	sol::function i = lua["i"];
+	sol::function sf = lua["sf"];
 
 	// Set a global variable called 
 	// "arr" to be a vector of 5 lements
@@ -315,6 +321,12 @@ end
 	REQUIRE(arr.size() == 6);
 	REQUIRE(map.size() == 6);
 	REQUIRE(set.size() == 6);
+
+	int r = sf(set, 8);
+	REQUIRE(r == 8);
+
+	sol::object rn = sf(set, 9);
+	REQUIRE(rn == sol::nil);
 
 	i(lua["arr"]);
 	i(lua["map"]);

--- a/test_containers.cpp
+++ b/test_containers.cpp
@@ -322,11 +322,19 @@ end
 	REQUIRE(map.size() == 6);
 	REQUIRE(set.size() == 6);
 
-	int r = sf(set, 8);
-	REQUIRE(r == 8);
+	{
+		int r = sf(set, 8);
+		REQUIRE(r == 8);
+		sol::object rn = sf(set, 9);
+		REQUIRE(rn == sol::nil);
+	}
 
-	sol::object rn = sf(set, 9);
-	REQUIRE(rn == sol::nil);
+	{
+		int r = sf(map, 3);
+		REQUIRE(r == 6);
+		sol::object rn = sf(map, 9);
+		REQUIRE(rn == sol::nil);
+	}
 
 	i(lua["arr"]);
 	i(lua["map"]);


### PR DESCRIPTION
std::[unordered_]set had no way to perform a lookup from the Lua side (other than iterating), and I saw in #196 it wasn't desired to have table-like access for lookups, so I added a :find to the container metatable.