### PR TITLE
Added comparison operator to reference

### DIFF
--- a/sol/reference.hpp
+++ b/sol/reference.hpp
@@ -224,6 +224,10 @@ namespace sol {
 		return lua_compare(l.lua_state(), -1, -2, LUA_OPEQ) == 1;
 	}
 
+	inline bool operator< (const reference& l, const reference& r) {
+		return !(l == r);
+	}
+
 	inline bool operator!= (const reference& l, const reference& r) {
 		return !operator==(l, r);
 	}


### PR DESCRIPTION
... to allow for sol::functions to be used as a key in `std::set`, `std::map` etc containers.

Ugly hack, and may be possible to do it more properly (to make it actually ordered!), but this should work good enough in a `std::set` for example