### PR TITLE
fix usage of unique_ and shared_ptr as non-unique-usertype

### DIFF
--- a/sol/traits.hpp
+++ b/sol/traits.hpp
@@ -407,6 +407,16 @@ namespace sol {
 			return *item;
 		}
 
+		template <typename T>
+		inline const T& deref(const T& item) {
+			return item;
+		}
+
+		template <typename T>
+		inline T& deref(T& item) {
+			return item;
+		}
+
 		template<typename T, typename Dx>
 		inline std::add_lvalue_reference_t<T> deref(std::unique_ptr<T, Dx>& item) {
 			return *item;

--- a/sol/usertype_metatable.hpp
+++ b/sol/usertype_metatable.hpp
@@ -413,7 +413,7 @@ namespace sol {
 					}
 					else {
 						Op op;
-						return stack::push(L, (detail::ptr(l) == detail::ptr(r)) || op(detail::deref(l), detail::deref(r)));
+						return stack::push(L, (detail::ptr(l) == detail::ptr(r)) || op(detail::deref<T>(l), detail::deref<T>(r)));
 					}
 				}
 			}

--- a/test_usertypes.cpp
+++ b/test_usertypes.cpp
@@ -265,6 +265,13 @@ struct matrix_xi {
 	}
 };
 
+struct type_without_unique_usertypes {};
+
+namespace sol{
+	template <> struct is_unique_usertype<std::unique_ptr<type_without_unique_usertypes>> : std::false_type {};
+	template <> struct is_unique_usertype<std::shared_ptr<type_without_unique_usertypes>> : std::false_type {};
+}
+
 TEST_CASE("usertype/usertype", "Show that we can create classes from usertype and use them") {
 	sol::state lua;
 
@@ -1808,4 +1815,10 @@ TEST_CASE("usertype/meta-key-retrievals", "allow for special meta keys (__index,
 		REQUIRE(keys[2] == "__index");
 		REQUIRE(keys[3] == "__call");
 	}
+}
+
+TEST_CASE("usertype/unique-shared-ptr-as-non-unique-usertype", "allow for unique_ptr and shared_ptr specializations to be usertypes when they opt out of unique_usertype handling") {
+	sol::state lua;
+	lua.new_usertype<std::unique_ptr<type_without_unique_usertypes>>("up_non_unique");
+	lua.new_usertype<std::shared_ptr<type_without_unique_usertypes>>("sp_non_unique");
 }


### PR DESCRIPTION
This PR allows std::unique_ptr and std::shared_ptr to be used as usertypes (if the unique_usertype trait for the specific specialization has been disabled, I didn't put much thought into whether it would make any sense otherwise).
Includes a test case (leads to compilation errors on develop), a 100% safe fix for the issue itself (incorrect detail::deref overload) and a 99% safe workaround for the new usage of detail::deref; see the (surprisingly small) commits for details.
(P.S.: The test suite is _really_ easy to set up if you just `pip install ninja` and play with include/library directories/flags. Cool stuff.)