### PR TITLE
Fix compilation on Max OS X with lua 5.1

### DIFF
--- a/sol/compatibility/5.x.x.inl
+++ b/sol/compatibility/5.x.x.inl
@@ -319,7 +319,7 @@ inline int luaL_fileresult(lua_State *L, int stat, const char *fname) {
     }
     else {
         char buf[1024];
-#if defined(__GLIBC__) || defined(_POSIX_VERSION)
+#if defined(__GLIBC__) || defined(_POSIX_VERSION) || defined(__APPLE__)
         strerror_r(en, buf, 1024);
 #else
         strerror_s(buf, 1024, en);


### PR DESCRIPTION
`_POSIX_VERSION` - [defined at `unistd.h` header file.](https://www.gnu.org/software/libc/manual/html_node/Version-Supported.html)
sol2 doesn't include this header
On Mac OS this leads to an error.
Predefined macro `__APPLE__` looks good option to test for `strerror_r` presence.