### PR TITLE
enable move semantics when pushing sol::optional<T>

### DIFF
--- a/sol/stack_push.hpp
+++ b/sol/stack_push.hpp
@@ -26,6 +26,7 @@
 #include "raii.hpp"
 #include "optional.hpp"
 #include <memory>
+#include <type_traits>
 #ifdef SOL_CODECVT_SUPPORT
 #include <codecvt>
 #include <locale>
@@ -703,7 +704,7 @@ namespace sol {
 				if (t == nullopt) {
 					return stack::push(L, nullopt);
 				}
-				return stack::push(L, t.value());
+				return stack::push(L, static_cast<std::conditional_t<std::is_lvalue_reference<T>::value, O&, O&&>>(t.value()));
 			}
 		};
 

--- a/test_tables.cpp
+++ b/test_tables.cpp
@@ -572,3 +572,14 @@ print(tbl[1])
 	REQUIRE(v1 == 30);
 	REQUIRE(v2 == 40);
 }
+
+TEST_CASE("tables/optional-move", "ensure pushing a sol::optional<T> rvalue correctly moves the contained object"){
+	sol::state sol_state;
+	struct move_only{
+		int secret_code;
+		move_only(const move_only&) = delete;
+		move_only(move_only&&) = default;
+	};
+	sol_state["requires_move"] = sol::optional<move_only>{move_only{0x4D}};
+	REQUIRE(sol_state["requires_move"].get<move_only>().secret_code == 0x4D);
+}


### PR DESCRIPTION
A rather straight-forward fix; `sol::optional<T>`'s `stack::pusher` specialization takes the `optional` by forwarding reference but then simply pushes `t.value()`.
This commit adds a `static_cast` that correctly forwards the contained value according to the argument's reference type. (A general `forward_like` utility function might be handy, but I wasn't sure where to put it and if it's the only use case then it doesn't really matter yet.)
Test case (move-only struct, a `sol::optional` of which cannot be pushed before the fix) included (in `test_tables.cpp`, because I couldn't think of a better place to put it).