### PR TITLE
Large integer support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,29 @@ matrix:
           - ninja-build
           - libluajit-5.1-dev
 
+    # gcc-5:i386
+    - os: linux
+      env: COMPILER=g++-5 LUA_VERSION=luajit51:i386
+      compiler: gcc
+      install:
+       - sudo dpkg --add-architecture i386
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-5
+          - g++-5
+          - ninja-build
+          - libluajit-5.1-dev
+          - libluajit-5.1-dev:i386
+          - libc6:i386
+          - libncurses5:i386
+          - libstdc++6:i386
+          - gcc-5-multilib
+          - g++-5-multilib
+          - linux-libc-dev:i386
+
     # clang
     - os: linux
       env:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -91,6 +91,12 @@ if 'linux' in sys.platform:
         # Using normal lua
         lua_lib = lua_version[:-1] + '.' + lua_version[-1]
         lua_incl = lua_lib
+    elif re.match(r'luajit5[1-3]:i386', lua_version):
+        # luajit:i386
+        lua_incl = 'luajit-2.0'
+        lua_lib = lua_version[:-7] + '-' + lua_version[-7] + '.' + lua_version[-6]
+        cxxflags.append('-m32')
+        include.extend(['/usr/include/luajit-2.0/', '/usr/local/include/luajit-2.0/'])
     elif re.match(r'luajit5[1-3]', lua_version):
         # luajit
         lua_incl = 'luajit-2.0' # I don't get this..

--- a/sol/stack_check.hpp
+++ b/sol/stack_check.hpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <functional>
 #include <utility>
+#include <cmath>
 #ifdef SOL_CXX17_FEATURES
 #include <variant>
 #endif // C++17
@@ -85,7 +86,14 @@ namespace sol {
 			template <typename Handler>
 			static bool check(lua_State* L, int index, Handler&& handler, record& tracking) {
 				tracking.use(1);
-				bool success = lua_isinteger(L, index) == 1;
+#if SOL_LUA_VERSION >= 503
+				if (lua_isinteger(L, index) != 0) {
+					return true;
+				}
+#endif
+				int isnum = 0;
+				const lua_Number v = lua_tonumberx(L, index, &isnum);
+				const bool success = isnum != 0 && static_cast<lua_Number>(std::llround(v)) == v;
 				if (!success) {
 					// expected type, actual type
 					handler(L, index, type::number, type_of(L, index));

--- a/sol/stack_get.hpp
+++ b/sol/stack_get.hpp
@@ -31,6 +31,7 @@
 #include <functional>
 #include <utility>
 #include <cstdlib>
+#include <cmath>
 #ifdef SOL_CODECVT_SUPPORT
 #include <codecvt>
 #include <locale>
@@ -59,18 +60,15 @@ namespace sol {
 		};
 
 		template<typename T>
-		struct getter<T, std::enable_if_t<meta::all<std::is_integral<T>, std::is_signed<T>>::value>> {
+		struct getter<T, std::enable_if_t<std::is_integral<T>::value>> {
 			static T get(lua_State* L, int index, record& tracking) {
 				tracking.use(1);
-				return static_cast<T>(lua_tointeger(L, index));
-			}
-		};
-
-		template<typename T>
-		struct getter<T, std::enable_if_t<meta::all<std::is_integral<T>, std::is_unsigned<T>>::value>> {
-			static T get(lua_State* L, int index, record& tracking) {
-				tracking.use(1);
-				return static_cast<T>(lua_tointeger(L, index));
+#if SOL_LUA_VERSION >= 503
+				if (lua_isinteger(L, index) != 0) {
+					return static_cast<T>(lua_tointeger(L, index));
+				}
+#endif
+				return static_cast<T>(std::llround(lua_tonumber(L, index)));
 			}
 		};
 

--- a/test_large_integer.cpp
+++ b/test_large_integer.cpp
@@ -1,0 +1,117 @@
+#define SOL_CHECK_ARGUMENTS
+#include <sol.hpp>
+
+#include <catch.hpp>
+#include <cstdint>
+#include <limits>
+
+TEST_CASE("large_integer/bool", "pass bool integral value to and from lua") {
+	sol::state lua;
+	lua.open_libraries();
+	lua.set_function("f", [&](bool num) {
+		REQUIRE(num == true);
+		return num;
+	});
+	lua.script("x = f(true)");
+	lua.script("assert(x == true)");
+	sol::object x = lua["x"];
+	REQUIRE(x.is<bool>());
+	REQUIRE(x.as<bool>() == true);
+	REQUIRE_FALSE(x.is<std::int32_t>());
+	REQUIRE_THROWS([&lua]() {
+		lua.script("f(1)");
+	}());
+}
+
+TEST_CASE("large_integers/unsigned32", "pass large unsigned 32bit values to and from lua") {
+	using T = std::uint32_t;
+	sol::state lua;
+	lua.open_libraries();
+	lua.set_function("f", [&](T num) -> T {
+		REQUIRE(num == 0xFFFFFFFF);
+		return num;
+	});
+	lua.script("x = f(0xFFFFFFFF)");
+	lua.script("assert(x == 0xFFFFFFFF)");
+	sol::object x = lua["x"];
+	REQUIRE(x.is<T>());
+	REQUIRE(x.as<T>() == 0xFFFFFFFF);
+}
+
+TEST_CASE("large_integer/unsigned53", "pass large unsigned 53bit value to and from lua") {
+	using T = std::uint64_t;
+	sol::state lua;
+	lua.open_libraries();
+	lua.set_function("f", [&](T num) -> T {
+		REQUIRE(num == 0x1FFFFFFFFFFFFFull);
+		return num;
+	});
+	lua.script("x = f(0x1FFFFFFFFFFFFF)");
+	lua.script("assert(x == 0x1FFFFFFFFFFFFF)");
+	sol::object x = lua["x"];
+	REQUIRE(x.is<T>());
+	REQUIRE(x.as<T>() == 0x1FFFFFFFFFFFFFull);
+}
+
+TEST_CASE("large_integer/unsigned64", "pass too large unsigned 64bit value to lua") {
+	using T = std::int64_t;
+	sol::state lua;
+	lua.open_libraries();
+	lua.set_function("f", [&](T num) -> T {
+		return num;
+	});
+	REQUIRE_THROWS([&lua]() {
+		lua["f"](0xFFFFFFFFFFFFFFFFull);
+	}());
+}
+
+TEST_CASE("large_integer/double", "pass negative and large positive values as signed and unsigned from and to lua") {
+	sol::state lua;
+	lua.open_libraries();
+	lua.set_function("s32", [&](std::int32_t num) {
+		return num;
+	});
+    lua.set_function("s64", [&](std::int64_t num) {
+		return num;
+	});
+	lua.set_function("u32", [&](std::uint32_t num) {
+		return num;
+	});
+	lua.set_function("u64", [&](std::uint64_t num) {
+		return num;
+	});
+	//signed 32bit
+	REQUIRE_NOTHROW([&lua]() {
+		lua.script("x = s32(-1)");
+		lua.script("assert(x == -1)");
+		lua.script("x = s32(0xFFFFFFFF)");
+		lua.script("assert(x == -1)");
+		sol::object x = lua["x"];
+		REQUIRE(x.is<std::int32_t>());
+		REQUIRE(x.as<std::int32_t>() == -1);
+		REQUIRE(x.is<std::uint32_t>());
+		REQUIRE(x.as<std::uint32_t>() == 0xFFFFFFFF);
+	}());
+	//unsigned 32bit
+	REQUIRE_NOTHROW([&lua]() {
+		lua.script("x = u32(0xFFFFFFFF)");
+		lua.script("assert(x == 0xFFFFFFFF)");
+		lua.script("x = u32(-1)");
+		lua.script("assert(x == 0xFFFFFFFF)");
+		sol::object x = lua["x"];
+		REQUIRE(x.is<std::int32_t>());
+		REQUIRE(x.as<std::int32_t>() == -1);
+		REQUIRE(x.is<std::uint32_t>());
+		REQUIRE(x.as<std::uint32_t>() == 0xFFFFFFFF);
+	}());
+	//signed 64bit
+	REQUIRE_NOTHROW([&lua]() {
+		lua.script("x = s64(-1)");
+		lua.script("assert(x == -1)");
+		sol::object x = lua["x"];
+		REQUIRE(x.is<std::int64_t>());
+		REQUIRE(x.as<std::int64_t>() == -1);
+		REQUIRE(x.is<std::uint64_t>());
+		REQUIRE(x.as<std::uint64_t>() == 0xFFFFFFFFFFFFFFFFull);
+	}());
+}


### PR DESCRIPTION
This PR adds large integer support for x86 and integer misrepresentation detection for x86/x64.
sol2 will still try to use lua_Integer wherever it is safe to do so, only when the value can't possibly fit in lua_Integer, it uses lua_Number as fallback with optional runtime checks to make sure the floating point value still represents the integer accurately.

Would appreciate any feedback or concerns, if there are any.

See #470

- [x] large integer changes
- [x] tests
- [x] working linux:i386 build
- [x] passes travis-ci (as good as _develop_)
- [ ] reviewed

unrelated to this PR: 
- The build for the original develop branch is currently broken, I'll update my fork from upstream as soon as it's fixed.
- currently both linux:i386 and windows:x86 are failing some tests on upstream/develop (at least with the latest luajit) maybe we could have some i386 builds on travis?
- you manually need to set SOL_EXCEPTIONS_SAFE_PROPAGATION under windows x86/luajit2.1b3 (the new versions have proper exception handling under windows x86 with \EHsc)
- single.py is failing with python2.7 and only works with python3
- it would be nice to have a build config that runs with msvc that you don't need to create yourself