### PR TITLE
allocate userdata with proper alignment

### DIFF
--- a/sol/call.hpp
+++ b/sol/call.hpp
@@ -211,10 +211,10 @@ namespace sol {
 			call_syntax syntax = argcount > 0 ? stack::get_call_syntax(L, &usertype_traits<T>::user_metatable()[0], 1) : call_syntax::dot;
 			argcount -= static_cast<int>(syntax);
 
-			T** pointerpointer = reinterpret_cast<T**>(lua_newuserdata(L, sizeof(T*) + sizeof(T)));
-			T*& referencepointer = *pointerpointer;
-			T* obj = reinterpret_cast<T*>(pointerpointer + 1);
-			referencepointer = obj;
+			T* obj = nullptr;
+			void* userdata = nullptr;
+			detail::user_aligned_alloc<T>(L, sizeof(T*), userdata, obj);
+			*reinterpret_cast<T**>(userdata) = obj;
 			reference userdataref(L, -1);
 			userdataref.pop();
 
@@ -513,11 +513,11 @@ namespace sol {
 				call_syntax syntax = argcount > 0 ? stack::get_call_syntax(L, &usertype_traits<T>::user_metatable()[0], 1) : call_syntax::dot;
 				argcount -= static_cast<int>(syntax);
 
-				T** pointerpointer = reinterpret_cast<T**>(lua_newuserdata(L, sizeof(T*) + sizeof(T)));
+				T* obj = nullptr;
+				void* userdata = nullptr;
+				detail::user_aligned_alloc<T>(L, sizeof(T*), userdata, obj);
+				*reinterpret_cast<T**>(userdata) = obj;
 				reference userdataref(L, -1);
-				T*& referencepointer = *pointerpointer;
-				T* obj = reinterpret_cast<T*>(pointerpointer + 1);
-				referencepointer = obj;
 
 				construct_match<T, Args...>(constructor_match<T, false, clean_stack>(obj), L, argcount, boost + 1 + static_cast<int>(syntax));
 
@@ -541,12 +541,13 @@ namespace sol {
 				template <typename Fx, std::size_t I, typename... R, typename... Args>
 				int operator()(types<Fx>, index_value<I>, types<R...> r, types<Args...> a, lua_State* L, int, int start, F& f) {
 					const auto& metakey = usertype_traits<T>::metatable();
-					T** pointerpointer = reinterpret_cast<T**>(lua_newuserdata(L, sizeof(T*) + sizeof(T)));
-					reference userdataref(L, -1);
-					T*& referencepointer = *pointerpointer;
-					T* obj = reinterpret_cast<T*>(pointerpointer + 1);
-					referencepointer = obj;
 
+					T* obj = nullptr;
+					void* userdata = nullptr;
+					detail::user_aligned_alloc<T>(L, sizeof(T*), userdata, obj);
+					*reinterpret_cast<T**>(userdata) = obj;
+					reference userdataref(L, -1);
+					
 					auto& func = std::get<I>(f.functions);
 					stack::call_into_lua<checked, clean_stack>(r, a, L, boost + start, func, detail::implicit_wrapper<T>(obj));
 


### PR DESCRIPTION
This PR should fix #514.

Basically if we detect that the memory returned by lua_newuserdata isn't aligned after sol adds it bookkeeping, reallocate and align it manually. This should only happen rarely though. The only other alternatives to this approach are either 
- allocating seperately with another aligned allocator like `new`, but then we need a `__gc` metamethod for everything to be able call `delete` afterwards.
- or always allocating more space than we really need to be able to align the memory afterwards. (performance vs memory tradeoff)

Would love a review, it's easy to miss dependencies when tinkering with the inner workings of the library.