### PR TITLE
types: add missing static_trampoline_noexcept

### DIFF
--- a/sol/types.hpp
+++ b/sol/types.hpp
@@ -57,6 +57,11 @@ namespace sol {
 		int static_trampoline_noexcept(lua_State* L) noexcept {
 			return f(L);
 		}
+#else
+		template <lua_CFunction f>
+		int static_trampoline_noexcept(lua_State* L) noexcept {
+			return f(L);
+		}
 #endif
 
 		template <typename Fx, typename... Args>


### PR DESCRIPTION
when SOL_NOEXCEPT_FUNCTION_TYPE isn't defined.