### PR TITLE
 Compile fix for std::variant detection on Apple clang 9.1.0 (Xcode 9.3)

### DIFF
--- a/single/sol/sol.hpp
+++ b/single/sol/sol.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2018-04-13 06:36:50.935900 UTC
-// This header was generated with sol v2.19.5 (revision 9ad8fd8)
+// Generated 2018-04-13 18:36:16.622867 UTC
+// This header was generated with sol v2.19.5 (revision d9aef04)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_HPP
@@ -5467,10 +5467,12 @@ namespace sol {
 		template <>
 		struct lua_type_of<meta_function> : std::integral_constant<type, type::string> {};
 
+#ifdef SOL_CXX17_FEATURES
 #ifdef SOL_STD_VARIANT
 		template <typename... Tn>
 		struct lua_type_of<std::variant<Tn...>> : std::integral_constant<type, type::poly> {};
-#endif // C++17 variant
+#endif // SOL_STD_VARIANT
+#endif // SOL_CXX17_FEATURES
 
 		template <typename T>
 		struct lua_type_of<nested<T>, std::enable_if_t<::sol::is_container<T>::value>> : std::integral_constant<type, type::table> {};
@@ -7836,8 +7838,10 @@ namespace sol {
 // end of sol/inheritance.hpp
 
 #include <cmath>
+#ifdef SOL_CXX17_FEATURES
 #ifdef SOL_STD_VARIANT
-#endif // C++17 variant
+#endif // SOL_STD_VARIANT
+#endif // SOL_CXX17_FEATURES
 
 namespace sol {
 namespace stack {
@@ -8379,6 +8383,7 @@ namespace stack {
 		}
 	};
 
+#ifdef SOL_CXX17_FEATURES
 #ifdef SOL_STD_VARIANT
 	template <typename... Tn, typename C>
 	struct checker<std::variant<Tn...>, type::poly, C> {
@@ -8410,7 +8415,8 @@ namespace stack {
 			return is_one(std::integral_constant<std::size_t, V_size::value>(), L, index, std::forward<Handler>(handler), tracking);
 		}
 	};
-#endif // C++17 variant
+#endif // SOL_STD_VARIANT
+#endif // SOL_CXX17_FEATURES
 }
 } // namespace sol::stack
 
@@ -9589,8 +9595,8 @@ namespace stack {
 			return get_one(std::integral_constant<std::size_t, V_size::value>(), L, index, tracking);
 		}
 	};
-#endif // Apple Clang screwed up
-#endif // C++17-wave
+#endif // SOL_STD_VARIANT
+#endif // SOL_CXX17_FEATURES
 }
 } // namespace sol::stack
 
@@ -9711,6 +9717,7 @@ namespace stack {
 		}
 	};
 
+#ifdef SOL_CXX17_FEATURES
 #ifdef SOL_STD_VARIANT
 	template <typename... Tn>
 	struct check_getter<std::variant<Tn...>> {
@@ -9751,7 +9758,8 @@ namespace stack {
 			return get_one(std::integral_constant<std::size_t, V_size::value>(), L, index, std::forward<Handler>(handler), tracking);
 		}
 	};
-#endif // C++17 variant
+#endif // SOL_STD_VARIANT
+#endif // SOL_CXX17_FEATURES
 }
 } // namespace sol::stack
 

--- a/single/sol/sol.hpp
+++ b/single/sol/sol.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2018-04-12 18:01:15.071442 UTC
-// This header was generated with sol v2.19.5 (revision 80df3fc)
+// Generated 2018-04-13 06:36:50.935900 UTC
+// This header was generated with sol v2.19.5 (revision 9ad8fd8)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_HPP
@@ -77,9 +77,11 @@
 #endif // noexcept is part of a function's type
 #endif // compiler-specific checks
 #if defined(__clang__) && defined(__APPLE__)
-#if __has_include && __has_include(<variant>)
+#if defined(__has_include)
+#if __has_include(<variant>)
 #define SOL_STD_VARIANT 1
 #endif // has include nonsense
+#endif // __has_include
 #else
 #define SOL_STD_VARIANT 1
 #endif // Clang screws up variant
@@ -4522,7 +4524,9 @@ namespace sol {
 // end of sol/filters.hpp
 
 #ifdef SOL_CXX17_FEATURES
+#ifdef SOL_STD_VARIANT
 #include <variant>
+#endif
 #endif // C++17
 #ifdef SOL_USE_BOOST
 #include <boost/unordered_map.hpp>
@@ -5463,10 +5467,10 @@ namespace sol {
 		template <>
 		struct lua_type_of<meta_function> : std::integral_constant<type, type::string> {};
 
-#ifdef SOL_CXX17_FEATURES
+#ifdef SOL_STD_VARIANT
 		template <typename... Tn>
 		struct lua_type_of<std::variant<Tn...>> : std::integral_constant<type, type::poly> {};
-#endif // C++ 17 (or not) features
+#endif // C++17 variant
 
 		template <typename T>
 		struct lua_type_of<nested<T>, std::enable_if_t<::sol::is_container<T>::value>> : std::integral_constant<type, type::table> {};
@@ -7832,8 +7836,8 @@ namespace sol {
 // end of sol/inheritance.hpp
 
 #include <cmath>
-#ifdef SOL_CXX17_FEATURES
-#endif // C++17
+#ifdef SOL_STD_VARIANT
+#endif // C++17 variant
 
 namespace sol {
 namespace stack {
@@ -8375,7 +8379,7 @@ namespace stack {
 		}
 	};
 
-#ifdef SOL_CXX17_FEATURES
+#ifdef SOL_STD_VARIANT
 	template <typename... Tn, typename C>
 	struct checker<std::variant<Tn...>, type::poly, C> {
 		typedef std::variant<Tn...> V;
@@ -8406,7 +8410,7 @@ namespace stack {
 			return is_one(std::integral_constant<std::size_t, V_size::value>(), L, index, std::forward<Handler>(handler), tracking);
 		}
 	};
-#endif // C++17
+#endif // C++17 variant
 }
 } // namespace sol::stack
 
@@ -9707,7 +9711,7 @@ namespace stack {
 		}
 	};
 
-#ifdef SOL_CXX17_FEATURES
+#ifdef SOL_STD_VARIANT
 	template <typename... Tn>
 	struct check_getter<std::variant<Tn...>> {
 		typedef std::variant<Tn...> V;
@@ -9747,7 +9751,7 @@ namespace stack {
 			return get_one(std::integral_constant<std::size_t, V_size::value>(), L, index, std::forward<Handler>(handler), tracking);
 		}
 	};
-#endif // C++17
+#endif // C++17 variant
 }
 } // namespace sol::stack
 

--- a/single/sol/sol_forward.hpp
+++ b/single/sol/sol_forward.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2018-04-12 18:01:15.385481 UTC
-// This header was generated with sol v2.19.5 (revision 80df3fc)
+// Generated 2018-04-13 06:36:51.034348 UTC
+// This header was generated with sol v2.19.5 (revision 9ad8fd8)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_FORWARD_HPP
@@ -44,9 +44,11 @@
 #endif // noexcept is part of a function's type
 #endif // compiler-specific checks
 #if defined(__clang__) && defined(__APPLE__)
-#if __has_include && __has_include(<variant>)
+#if defined(__has_include)
+#if __has_include(<variant>)
 #define SOL_STD_VARIANT 1
 #endif // has include nonsense
+#endif // __has_include
 #else
 #define SOL_STD_VARIANT 1
 #endif // Clang screws up variant

--- a/single/sol/sol_forward.hpp
+++ b/single/sol/sol_forward.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2018-04-13 06:36:51.034348 UTC
-// This header was generated with sol v2.19.5 (revision 9ad8fd8)
+// Generated 2018-04-13 18:36:16.720493 UTC
+// This header was generated with sol v2.19.5 (revision d9aef04)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_FORWARD_HPP

--- a/sol/feature_test.hpp
+++ b/sol/feature_test.hpp
@@ -41,9 +41,11 @@
 #endif // noexcept is part of a function's type
 #endif // compiler-specific checks
 #if defined(__clang__) && defined(__APPLE__)
-#if __has_include && __has_include(<variant>)
+#if defined(__has_include)
+#if __has_include(<variant>)
 #define SOL_STD_VARIANT 1
 #endif // has include nonsense
+#endif // __has_include
 #else
 #define SOL_STD_VARIANT 1
 #endif // Clang screws up variant

--- a/sol/stack_check.hpp
+++ b/sol/stack_check.hpp
@@ -31,9 +31,11 @@
 #include <functional>
 #include <utility>
 #include <cmath>
+#ifdef SOL_CXX17_FEATURES
 #ifdef SOL_STD_VARIANT
 #include <variant>
-#endif // C++17 variant
+#endif // SOL_STD_VARIANT
+#endif // SOL_CXX17_FEATURES
 
 namespace sol {
 namespace stack {
@@ -575,6 +577,7 @@ namespace stack {
 		}
 	};
 
+#ifdef SOL_CXX17_FEATURES
 #ifdef SOL_STD_VARIANT
 	template <typename... Tn, typename C>
 	struct checker<std::variant<Tn...>, type::poly, C> {
@@ -606,7 +609,8 @@ namespace stack {
 			return is_one(std::integral_constant<std::size_t, V_size::value>(), L, index, std::forward<Handler>(handler), tracking);
 		}
 	};
-#endif // C++17 variant
+#endif // SOL_STD_VARIANT
+#endif // SOL_CXX17_FEATURES
 }
 } // namespace sol::stack
 

--- a/sol/stack_check.hpp
+++ b/sol/stack_check.hpp
@@ -31,9 +31,9 @@
 #include <functional>
 #include <utility>
 #include <cmath>
-#ifdef SOL_CXX17_FEATURES
+#ifdef SOL_STD_VARIANT
 #include <variant>
-#endif // C++17
+#endif // C++17 variant
 
 namespace sol {
 namespace stack {
@@ -575,7 +575,7 @@ namespace stack {
 		}
 	};
 
-#ifdef SOL_CXX17_FEATURES
+#ifdef SOL_STD_VARIANT
 	template <typename... Tn, typename C>
 	struct checker<std::variant<Tn...>, type::poly, C> {
 		typedef std::variant<Tn...> V;
@@ -606,7 +606,7 @@ namespace stack {
 			return is_one(std::integral_constant<std::size_t, V_size::value>(), L, index, std::forward<Handler>(handler), tracking);
 		}
 	};
-#endif // C++17
+#endif // C++17 variant
 }
 } // namespace sol::stack
 

--- a/sol/stack_check_get.hpp
+++ b/sol/stack_check_get.hpp
@@ -144,7 +144,7 @@ namespace stack {
 		}
 	};
 
-#ifdef SOL_CXX17_FEATURES
+#ifdef SOL_STD_VARIANT
 	template <typename... Tn>
 	struct check_getter<std::variant<Tn...>> {
 		typedef std::variant<Tn...> V;
@@ -184,7 +184,7 @@ namespace stack {
 			return get_one(std::integral_constant<std::size_t, V_size::value>(), L, index, std::forward<Handler>(handler), tracking);
 		}
 	};
-#endif // C++17
+#endif // C++17 variant
 }
 } // namespace sol::stack
 

--- a/sol/stack_check_get.hpp
+++ b/sol/stack_check_get.hpp
@@ -144,6 +144,7 @@ namespace stack {
 		}
 	};
 
+#ifdef SOL_CXX17_FEATURES
 #ifdef SOL_STD_VARIANT
 	template <typename... Tn>
 	struct check_getter<std::variant<Tn...>> {
@@ -184,7 +185,8 @@ namespace stack {
 			return get_one(std::integral_constant<std::size_t, V_size::value>(), L, index, std::forward<Handler>(handler), tracking);
 		}
 	};
-#endif // C++17 variant
+#endif // SOL_STD_VARIANT
+#endif // SOL_CXX17_FEATURES
 }
 } // namespace sol::stack
 

--- a/sol/stack_get.hpp
+++ b/sol/stack_get.hpp
@@ -879,8 +879,8 @@ namespace stack {
 			return get_one(std::integral_constant<std::size_t, V_size::value>(), L, index, tracking);
 		}
 	};
-#endif // Apple Clang screwed up
-#endif // C++17-wave
+#endif // SOL_STD_VARIANT
+#endif // SOL_CXX17_FEATURES
 }
 } // namespace sol::stack
 

--- a/sol/types.hpp
+++ b/sol/types.hpp
@@ -39,7 +39,9 @@
 #include <string>
 #ifdef SOL_CXX17_FEATURES
 #include <string_view>
+#ifdef SOL_STD_VARIANT
 #include <variant>
+#endif
 #endif // C++17
 #ifdef SOL_USE_BOOST
 #include <boost/unordered_map.hpp>
@@ -980,10 +982,10 @@ namespace sol {
 		template <>
 		struct lua_type_of<meta_function> : std::integral_constant<type, type::string> {};
 
-#ifdef SOL_CXX17_FEATURES
+#ifdef SOL_STD_VARIANT
 		template <typename... Tn>
 		struct lua_type_of<std::variant<Tn...>> : std::integral_constant<type, type::poly> {};
-#endif // C++ 17 (or not) features
+#endif // C++17 variant
 
 		template <typename T>
 		struct lua_type_of<nested<T>, std::enable_if_t<::sol::is_container<T>::value>> : std::integral_constant<type, type::table> {};

--- a/sol/types.hpp
+++ b/sol/types.hpp
@@ -982,10 +982,12 @@ namespace sol {
 		template <>
 		struct lua_type_of<meta_function> : std::integral_constant<type, type::string> {};
 
+#ifdef SOL_CXX17_FEATURES
 #ifdef SOL_STD_VARIANT
 		template <typename... Tn>
 		struct lua_type_of<std::variant<Tn...>> : std::integral_constant<type, type::poly> {};
-#endif // C++17 variant
+#endif // SOL_STD_VARIANT
+#endif // SOL_CXX17_FEATURES
 
 		template <typename T>
 		struct lua_type_of<nested<T>, std::enable_if_t<::sol::is_container<T>::value>> : std::integral_constant<type, type::table> {};


### PR DESCRIPTION
- Recent commit 80df3fc915a47087d8ae0831768b29c1171e6da2 didn't compile because of the __has_include check
 fixed according to https://clang.llvm.org/docs/LanguageExtensions.html#has-include
- Added SOL_STD_VARIANT ifdefs where variant is actually used