### PR TITLE
Add support for plain arrays in sol::as_table

### DIFF
--- a/sol/stack_core.hpp
+++ b/sol/stack_core.hpp
@@ -529,6 +529,11 @@ namespace sol {
 				return static_cast<int>(c.size());
 			}
 
+			template <typename C, size_t N>
+			static int get_size_hint(const C (&c)[N]) {
+				return static_cast<int>(N);
+			}
+
 			template <typename V, typename Al>
 			static int get_size_hint(const std::forward_list<V, Al>&) {
 				// forward_list makes me sad

--- a/sol/types.hpp
+++ b/sol/types.hpp
@@ -395,6 +395,10 @@ namespace sol {
 		as_table_t(Arg&& arg)
 		: source(std::forward<Arg>(arg)) {
 		}
+		template <typename Arg, size_t N, meta::enable<meta::neg<std::is_same<meta::unqualified_t<Arg>, as_table_t>>, meta::neg<std::is_base_of<proxy_base_tag, meta::unqualified_t<Arg>>>> = meta::enabler>
+		as_table_t(Arg (&arg)[N]) {
+			std::copy(std::begin(arg),std::end(arg),std::begin(source));
+		}
 		template <typename Arg0, typename Arg1, typename... Args>
 		as_table_t(Arg0&& arg0, Arg1&& arg1, Args&&... args)
 		: source(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...) {


### PR DESCRIPTION
I hope my contribution meets the standards.
```cpp
#define SOL_CHECK_ARGUMENTS 1
#include <sol.hpp>

int main() {
    sol::state lua;
    lua.open_libraries(sol::lib::base);

    double d[] = { 11, 22, 33 };
    lua["test"] = sol::as_table(d);
    lua.script("for i,v in ipairs(test) do print(i,v) end");
    // It just werks!
}
```