### PR TITLE
Fix Exceptions Always Being Printed

### DIFF
--- a/single/sol/sol.hpp
+++ b/single/sol/sol.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2018-05-22 19:42:19.603781 UTC
-// This header was generated with sol v2.20.2 (revision d67c5b7)
+// Generated 2018-06-11 18:42:24.238190 UTC
+// This header was generated with sol v2.20.2 (revision ac70911)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_HPP
@@ -5787,7 +5787,7 @@ namespace sol {
 #include <exception>
 #include <cstring>
 
-#ifdef SOL_PRINT_ERRORS
+#if defined(SOL_PRINT_ERRORS) && SOL_PRINT_ERRORS
 #include <iostream>
 #endif
 
@@ -5805,7 +5805,7 @@ namespace sol {
 
 		// must push at least 1 object on the stack
 		inline int default_exception_handler(lua_State* L, optional<const std::exception&>, string_view what) {
-#ifdef SOL_PRINT_ERRORS
+#if defined(SOL_PRINT_ERRORS) && SOL_PRINT_ERRORS
 			std::cerr << "[sol2] An exception occurred: ";
 			std::cerr.write(what.data(), what.size());
 			std::cerr << std::endl;
@@ -20324,7 +20324,7 @@ namespace sol {
 
 // beginning of sol/state_handling.hpp
 
-#ifdef SOL_PRINT_ERRORS
+#if defined(SOL_PRINT_ERRORS) && SOL_PRINT_ERRORS
 #endif
 
 namespace sol {

--- a/single/sol/sol_forward.hpp
+++ b/single/sol/sol_forward.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2018-05-22 19:42:19.843589 UTC
-// This header was generated with sol v2.20.2 (revision d67c5b7)
+// Generated 2018-06-11 18:42:24.829810 UTC
+// This header was generated with sol v2.20.2 (revision ac70911)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_FORWARD_HPP

--- a/sol/state_handling.hpp
+++ b/sol/state_handling.hpp
@@ -29,7 +29,7 @@
 #include "function.hpp"
 #include "object.hpp"
 
-#ifdef SOL_PRINT_ERRORS
+#if defined(SOL_PRINT_ERRORS) && SOL_PRINT_ERRORS
 #include <iostream>
 #endif
 

--- a/sol/trampoline.hpp
+++ b/sol/trampoline.hpp
@@ -29,7 +29,7 @@
 #include <exception>
 #include <cstring>
 
-#ifdef SOL_PRINT_ERRORS
+#if defined(SOL_PRINT_ERRORS) && SOL_PRINT_ERRORS
 #include <iostream>
 #endif
 
@@ -47,7 +47,7 @@ namespace sol {
 
 		// must push at least 1 object on the stack
 		inline int default_exception_handler(lua_State* L, optional<const std::exception&>, string_view what) {
-#ifdef SOL_PRINT_ERRORS
+#if defined(SOL_PRINT_ERRORS) && SOL_PRINT_ERRORS
 			std::cerr << "[sol2] An exception occurred: ";
 			std::cerr.write(what.data(), what.size());
 			std::cerr << std::endl;


### PR DESCRIPTION
This PR fixes #652, which is about exceptions are always being printed. This was a very simple fix for a pretty inconsequential problem for most users. However, my application could really use those few KB freed by not needing `iostream`.

I'm not sure how I should update `single/`. I currently have it as a separate commit, but I can squash or drop it, to avoid clutter.