### PR TITLE
fix sol2-config.cmake.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ CMAKE_DEPENDENT_OPTION(TESTS_DYNAMIC_LOADING_EXAMPLES "Enable build of dynamic l
 add_library(sol2 INTERFACE)
 target_include_directories(sol2 INTERFACE
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-	$<INSTALL_INTERFACE:include/sol>)
+	$<INSTALL_INTERFACE:include>)
 
 # # Version configurations
 configure_package_config_file(

--- a/cmake/sol2-config.cmake.in
+++ b/cmake/sol2-config.cmake.in
@@ -26,13 +26,16 @@ include("${CMAKE_CURRENT_LIST_DIR}/sol2-targets.cmake")
 
 MESSAGE(STATUS ${CMAKE_CURRENT_LIST_DIR})
 
-get_target_property(SOL_INCLUDE_DIRS
-	sol2 INTERFACE_INCLUDE_DIRECTORIES)
+if (TARGET sol2)
+    get_target_property(SOL2_INCLUDE_DIRS
+        sol2 INTERFACE_INCLUDE_DIRECTORIES)
+    set_and_check(SOL2_INCLUDE_DIRS "${SOL2_INCLUDE_DIRS}")
+    set(SOL2_LIBRARIES sol2)
+endif()
 
-get_target_property(SOL_SINGLE_INCLUDE_DIRS
-	sol2_single INTERFACE_INCLUDE_DIRECTORIES)
-
-set_and_check(SOL2_INCLUDE_DIRS "${SOL2_INCLUDE_DIRS}")
-set_and_check(SOL2_INCLUDE_DIRS "${SOL2_SINGLE_INCLUDE_DIRS}")
-set(SOL2_LIBRARIES sol2)
-set(SOL2_LIBRARIES_SINGLE sol2_single)
+if(TARGET sol2_single)
+    get_target_property(SOL_SINGLE_INCLUDE_DIRS
+        sol2_single INTERFACE_INCLUDE_DIRECTORIES)
+    set_and_check(SOL2_INCLUDE_DIRS "${SOL2_SINGLE_INCLUDE_DIRS}")
+    set(SOL2_LIBRARIES_SINGLE sol2_single)
+endif()


### PR DESCRIPTION
It looks like there was a typo error, set a variable to SOL_INCLUDE_DIRS but use SOL2_INCLUDE_DIRS. And it is also possible that the installer of the library does not use sol2_single and if you do not activate the option SINGLE, you can not use it so you have to check that the target exists before.

This pull request will allow external c++ package manager to use sol2 properly with CMake. 