### PR TITLE
Fix build when SOL_STRINGS_ARE_NUMBERS is set

### DIFF
--- a/sol/stack_check_unqualified.hpp
+++ b/sol/stack_check_unqualified.hpp
@@ -149,9 +149,9 @@ namespace stack {
 			if (!success) {
 				// expected type, actual type
 #if defined(SOL_STRINGS_ARE_NUMBERS) && SOL_STRINGS_ARE_NUMBERS
-				handler(L, index, type::number, t, "not a numeric type");
-#else
 				handler(L, index, type::number, type_of(L, index), "not a numeric type or numeric string");
+#else
+				handler(L, index, type::number, t, "not a numeric type");
 #endif
 			}
 			return success;


### PR DESCRIPTION
Fixes a build error from compiling with lua 5.1 and `SOL_STRINGS_ARE_NUMBERS`:
```
sol2/single/sol/sol.hpp:8252:37: error: ‘t’ was not declared in this scope
     handler(L, index, type::number, t, "not a numeric type");
```