### PR TITLE
Fix unused variable warning

### DIFF
--- a/sol/stack_check_unqualified.hpp
+++ b/sol/stack_check_unqualified.hpp
@@ -140,12 +140,12 @@ namespace stack {
 			}
 #endif // Do not allow strings to be numbers
 			int isnum = 0;
-			const lua_Number v = lua_tonumberx(L, index, &isnum);
-			const bool success = isnum != 0
+
+			const bool success = isnum != 0;
 #if (defined(SOL_SAFE_NUMERICS) && SOL_SAFE_NUMERICS) && !(defined(SOL_NO_CHECK_NUMBER_PRECISION) && SOL_NO_CHECK_NUMBER_PRECISION)
-				&& static_cast<lua_Number>(llround(v)) == v
+			const lua_Number v = lua_tonumberx(L, index, &isnum);
+			success = success && (static_cast<lua_Number>(llround(v)) == v);
 #endif // Safe numerics and number precision checking
-				;
 			if (!success) {
 				// expected type, actual type
 #if defined(SOL_STRINGS_ARE_NUMBERS) && SOL_STRINGS_ARE_NUMBERS


### PR DESCRIPTION
This fixes unused variable warning by putting "v" variable declaration under #ifdef.