### PR TITLE
Pop stack element used as argument of lua_topointer

### DIFF
--- a/sol/reference.hpp
+++ b/sol/reference.hpp
@@ -432,6 +432,7 @@ namespace sol {
 		const void* pointer() const noexcept {
 			int si = push();
 			const void* vp = lua_topointer(lua_state(), -si);
+			pop();
 			return vp;
 		}
 


### PR DESCRIPTION
This fixes #717 by popping the stack element that was pushed to be the argument of `lua_topointer`