### PR TITLE
Inside sol::proxy::call, check if we're building with clang

### DIFF
--- a/single/sol/sol.hpp
+++ b/single/sol/sol.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2018-08-04 15:02:30.421859 UTC
-// This header was generated with sol v2.20.3 (revision daa9993)
+// Generated 2018-10-28 14:26:05.925454 UTC
+// This header was generated with sol v2.20.4 (revision a19a5a3)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_HPP
@@ -40,7 +40,7 @@
 #ifdef check
 #define SOL_INSIDE_UNREAL_REMOVED_CHECK 1
 #undef check
-#endif
+#endif 
 #endif // Unreal Engine 4 Bullshit
 
 #if defined(__GNUC__)
@@ -156,7 +156,7 @@
 	#define SOL_SAFE_REFERENCES 1
 	#endif
 
-	// Changes all typedefs of sol::function to point to the
+	// Changes all typedefs of sol::function to point to the 
 	// protected_function version, instead of unsafe_function
 	#if !defined(SOL_SAFE_FUNCTION)
 	#define SOL_SAFE_FUNCTION 1
@@ -186,7 +186,7 @@
 	#endif
 
 	// Turn off Number Precision Checks
-	// if this is defined, we do not do range
+	// if this is defined, we do not do range 
 	// checks on integers / unsigned integers that might
 	// be bigger than what Lua can represent
 	#if !defined(SOL_NO_CHECK_NUMBER_PRECISION)
@@ -246,7 +246,7 @@
 #ifndef SOL_UNORDERED_MAP_COMPATIBLE_HASH
 #define SOL_UNORDERED_MAP_COMPATIBLE_HASH 1
 #endif // SOL_UNORDERED_MAP_COMPATIBLE_HASH
-#endif
+#endif 
 
 #ifndef SOL_STACK_STRING_OPTIMIZATION_SIZE
 #define SOL_STACK_STRING_OPTIMIZATION_SIZE 1024
@@ -1171,7 +1171,7 @@ namespace sol {
 				hash ^= static_cast<size_t>(*cptr++);
 				hash *= static_cast<size_t>(1099511628211ULL);
 			}
-			return hash;
+			return hash; 
 #endif
 		}
 	};
@@ -1435,7 +1435,7 @@ namespace sol {
 			struct is_callable : std::is_function<std::remove_pointer_t<T>> {};
 
 			template <typename T>
-			struct is_callable<T, std::enable_if_t<std::is_final<unqualified_t<T>>::value
+			struct is_callable<T, std::enable_if_t<std::is_final<unqualified_t<T>>::value 
 				&& std::is_class<unqualified_t<T>>::value
 				&&  std::is_same<decltype(void(&T::operator())), void>::value>> {
 
@@ -1747,7 +1747,7 @@ namespace sol {
 		template <typename T>
 		using is_string_constructible = any<
 			meta::all<std::is_array<unqualified_t<T>>, std::is_same<meta::unqualified_t<std::remove_all_extents_t<meta::unqualified_t<T>>>, char>>,
-			std::is_same<unqualified_t<T>, const char*>,
+			std::is_same<unqualified_t<T>, const char*>, 
 			std::is_same<unqualified_t<T>, char>, std::is_same<unqualified_t<T>, std::string>, std::is_same<unqualified_t<T>, std::initializer_list<char>>
 #if defined(SOL_CXX17_FEATURES) && SOL_CXX17_FEATURES
 			, std::is_same<unqualified_t<T>, std::string_view>
@@ -5350,7 +5350,7 @@ namespace sol {
 			"__ipairs",
 			"next",
 			"__type",
-			"__typeinfo"
+			"__typeinfo" 
 		} };
 		return names;
 	}
@@ -5417,7 +5417,7 @@ namespace sol {
 		template <typename T>
 		struct is_container<T, std::enable_if_t<meta::all<
 			meta::has_begin_end<meta::unqualified_t<T>>
-			, meta::neg<is_initializer_list<meta::unqualified_t<T>>>
+			, meta::neg<is_initializer_list<meta::unqualified_t<T>>> 
 			, meta::neg<meta::is_string_like<meta::unqualified_t<T>>>
 		>::value
 		>> : std::true_type {};
@@ -5914,7 +5914,7 @@ namespace sol {
 			}
 #if !defined(SOL_EXCEPTIONS_SAFE_PROPAGATION)
 			// LuaJIT cannot have the catchall when the safe propagation is on
-			// but LuaJIT will swallow all C++ errors
+			// but LuaJIT will swallow all C++ errors 
 			// if we don't at least catch std::exception ones
 			catch (...) {
 				call_exception_handler(L, optional<const std::exception&>(nullopt), "caught (...) exception");
@@ -5925,7 +5925,7 @@ namespace sol {
 		}
 
 #ifdef SOL_NOEXCEPT_FUNCTION_TYPE
-#if 0
+#if 0 
 		// impossible: g++/clang++ choke as they think this function is ambiguous:
 		// to fix, wait for template <auto X> and then switch on no-exceptness of the function
 		template <lua_CFunction_noexcept f>
@@ -5968,7 +5968,7 @@ namespace sol {
 			}
 #if !defined(SOL_EXCEPTIONS_SAFE_PROPAGATION)
 			// LuaJIT cannot have the catchall when the safe propagation is on
-			// but LuaJIT will swallow all C++ errors
+			// but LuaJIT will swallow all C++ errors 
 			// if we don't at least catch std::exception ones
 			catch (...) {
 				call_exception_handler(L, optional<const std::exception&>(nullopt), "caught (...) exception");
@@ -6973,6 +6973,7 @@ namespace sol {
 		const void* pointer() const noexcept {
 			int si = push();
 			const void* vp = lua_topointer(lua_state(), -si);
+			lua_pop(this->lua_state(), si);
 			return vp;
 		}
 
@@ -7443,7 +7444,7 @@ namespace sol {
 					return false;
 				}
 				allocated_size -= sizeof(T*);
-
+				
 				adjusted = static_cast<void*>(static_cast<char*>(pointer_adjusted) + sizeof(T*));
 				dx_adjusted = align(std::alignment_of<unique_destructor>::value, sizeof(unique_destructor), adjusted, allocated_size);
 				if (dx_adjusted == nullptr) {
@@ -7451,7 +7452,7 @@ namespace sol {
 					return false;
 				}
 				allocated_size -= sizeof(unique_destructor);
-
+				
 				adjusted = static_cast<void*>(static_cast<char*>(dx_adjusted) + sizeof(unique_destructor));
 
 				id_adjusted = align(std::alignment_of<unique_tag>::value, sizeof(unique_tag), adjusted, allocated_size);
@@ -7460,7 +7461,7 @@ namespace sol {
 					return false;
 				}
 				allocated_size -= sizeof(unique_tag);
-
+				
 				adjusted = static_cast<void*>(static_cast<char*>(id_adjusted) + sizeof(unique_tag));
 				data_adjusted = align(std::alignment_of<Real>::value, sizeof(Real), adjusted, allocated_size);
 				if (data_adjusted == nullptr) {
@@ -8763,7 +8764,7 @@ namespace stack {
 	struct qualified_checker<X, type::userdata, std::enable_if_t<is_unique_usertype<X>::value && !std::is_reference<X>::value>> {
 		typedef unique_usertype_traits<meta::unqualified_t<X>> u_traits;
 		typedef typename u_traits::type T;
-
+		
 		template <typename Handler>
 		static bool check(std::false_type, lua_State* L, int index, Handler&& handler, record& tracking) {
 			return stack::unqualified_check<X>(L, index, std::forward<Handler>(handler), tracking);
@@ -8771,7 +8772,7 @@ namespace stack {
 
 		template <typename Handler>
 		static bool check(std::true_type, lua_State* L, int index, Handler&& handler, record& tracking) {
-			// we have a unique pointer type that can be
+			// we have a unique pointer type that can be 
 			// rebound to a base/derived type
 			const type indextype = type_of(L, index);
 			tracking.use(1);
@@ -8801,7 +8802,7 @@ namespace stack {
 			handler(L, index, type::userdata, indextype, "value is a userdata but is not the correct unique usertype");
 			return false;
 		}
-
+		
 		template <typename Handler>
 		static bool check(lua_State* L, int index, Handler&& handler, record& tracking) {
 			return check(meta::neg<std::is_void<typename u_traits::base_id>>(), L, index, std::forward<Handler>(handler), tracking);
@@ -9098,7 +9099,7 @@ namespace sol {
 				dr.error = error_code::invalid_code_point;
 				return dr;
 			}
-
+			
 			// then everything is fine
 			dr.codepoint = decoded;
 			dr.error = error_code::ok;
@@ -9116,7 +9117,7 @@ namespace sol {
 			}
 
 			char16_t lead = static_cast<char16_t>(*it);
-
+			
 			if (!unicode_detail::is_surrogate(lead)) {
 				++it;
 				dr.codepoint = static_cast<char32_t>(lead);
@@ -9137,7 +9138,7 @@ namespace sol {
 				dr.next = it;
 				return dr;
 			}
-
+			
 			dr.codepoint = unicode_detail::combine_surrogates(lead, trail);
 			dr.next = ++it;
 			dr.error = error_code::ok;
@@ -10074,10 +10075,10 @@ namespace stack {
 
 	template <typename T>
 	struct qualified_getter<T, std::enable_if_t<
-		!std::is_reference<T>::value
-		&& is_container<meta::unqualified_t<T>>::value
-		&& !is_lua_primitive<T>::value
-		&& !is_transparent_argument<T>::value
+		!std::is_reference<T>::value 
+		&& is_container<meta::unqualified_t<T>>::value 
+		&& !is_lua_primitive<T>::value 
+		&& !is_transparent_argument<T>::value 
 	>> {
 		static T get(lua_State* L, int index, record& tracking) {
 			if (type_of(L, index) == type::userdata) {
@@ -13463,7 +13464,7 @@ namespace sol {
 					const auto& meta = usertype_traits<T>::metatable();
 					T* obj = detail::usertype_allocate<T>(L);
 					reference userdataref(L, -1);
-
+					
 					auto& func = std::get<I>(f.functions);
 					stack::call_into_lua<checked, clean_stack>(r, a, L, boost + start, func, detail::implicit_wrapper<T>(obj));
 
@@ -14421,7 +14422,7 @@ namespace sol {
 			template <bool is_yielding, typename Fx, typename C>
 			static void select_member_variable(std::true_type, lua_State* L, Fx&& fx, function_detail::class_indicator<C>) {
 				lua_CFunction freefunc = &function_detail::upvalue_this_member_variable<C, Fx, is_yielding>::call;
-
+				
 				int upvalues = 0;
 				upvalues += stack::push(L, nullptr);
 				upvalues += stack::stack_detail::push_as_upvalues(L, fx);
@@ -14432,7 +14433,7 @@ namespace sol {
 			static void select_member_variable(std::true_type, lua_State* L, Fx&& fx) {
 				typedef typename meta::bind_traits<meta::unqualified_t<Fx>>::object_type C;
 				lua_CFunction freefunc = &function_detail::upvalue_this_member_variable<C, Fx, is_yielding>::call;
-
+				
 				int upvalues = 0;
 				upvalues += stack::push(L, nullptr);
 				upvalues += stack::stack_detail::push_as_upvalues(L, fx);
@@ -14474,7 +14475,7 @@ namespace sol {
 			template <bool is_yielding, typename Fx, typename C>
 			static void select_member_function(std::true_type, lua_State* L, Fx&& fx, function_detail::class_indicator<C>) {
 				lua_CFunction freefunc = &function_detail::upvalue_this_member_function<C, Fx, is_yielding>::call;
-
+				
 				int upvalues = 0;
 				upvalues += stack::push(L, nullptr);
 				upvalues += stack::stack_detail::push_as_upvalues(L, fx);
@@ -14485,7 +14486,7 @@ namespace sol {
 			static void select_member_function(std::true_type, lua_State* L, Fx&& fx) {
 				typedef typename meta::bind_traits<meta::unqualified_t<Fx>>::object_type C;
 				lua_CFunction freefunc = &function_detail::upvalue_this_member_function<C, Fx, is_yielding>::call;
-
+				
 				int upvalues = 0;
 				upvalues += stack::push(L, nullptr);
 				upvalues += stack::stack_detail::push_as_upvalues(L, fx);
@@ -15133,7 +15134,7 @@ namespace sol {
 			}
 #if (!defined(SOL_EXCEPTIONS_SAFE_PROPAGATION) || !SOL_NO_EXCEPTIONS_SAFE_PROPAGATION)
 			// LuaJIT cannot have the catchall when the safe propagation is on
-			// but LuaJIT will swallow all C++ errors
+			// but LuaJIT will swallow all C++ errors 
 			// if we don't at least catch std::exception ones
 			catch (...) {
 				onexcept(optional<const std::exception&>(nullopt), "caught (...) unknown error during protected_function call");
@@ -15220,7 +15221,7 @@ namespace sol {
 			stack::check<basic_protected_function>(lua_state(), -1, handler);
 #endif // Safety
 		}
-
+		
 		basic_protected_function(lua_nil_t n)
 			: base_t(n), error_handler(n) {
 		}
@@ -15513,7 +15514,7 @@ namespace sol {
 
 		template <typename... Ret, typename... Args>
 		decltype(auto) call(Args&&... args) {
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 191200000
+#if !defined(__clang__) && defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 191200000
 			// MSVC is ass sometimes
 			return get<function>().call<Ret...>(std::forward<Args>(args)...);
 #else
@@ -17892,7 +17893,7 @@ namespace sol {
 						std::remove_pointer_t<T>>>
 						meta_cumt;
 					static const char* metakey = is_shim ? &usertype_traits<as_container_t<std::remove_pointer_t<T>>>::metatable()[0] : &usertype_traits<T>::metatable()[0];
-					static const std::array<luaL_Reg, 19> reg = { {
+					static const std::array<luaL_Reg, 19> reg = { { 
 						{ "__pairs", &meta_cumt::pairs_call },
 						{ "__ipairs", &meta_cumt::ipairs_call },
 						{ "__len", &meta_cumt::length_call },
@@ -17911,7 +17912,7 @@ namespace sol {
 						{ "find", &meta_cumt::find_call },
 						{ "erase", &meta_cumt::erase_call },
 						std::is_pointer<T>::value ? luaL_Reg{ nullptr, nullptr } : luaL_Reg{ "__gc", &detail::usertype_alloc_destruct<T> },
-						{ nullptr, nullptr }
+						{ nullptr, nullptr } 
 					} };
 
 					if (luaL_newmetatable(L, metakey) == 1) {
@@ -18298,7 +18299,7 @@ namespace sol {
 			: index(index), new_index(newindex), runtime_target(runtimetarget) {
 			}
 		};
-
+		
 		typedef map_t<std::string, call_information> mapping_t;
 
 		struct variable_wrapper {
@@ -20767,7 +20768,7 @@ namespace sol {
 
 		template <typename... Ret, typename... Args>
 		decltype(auto) call(Args&&... args) {
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 191200000
+#if !defined(__clang__) && defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 191200000
 			// MSVC is ass sometimes
 			return get<protected_function>().call<Ret...>(std::forward<Args>(args)...);
 #else
@@ -22062,7 +22063,7 @@ namespace sol {
 #else
 #define check(expr) { CA_ASSUME(expr); }
 #endif
-#endif
+#endif 
 #endif // Unreal Engine 4 Bullshit
 
 #endif // SOL_HPP

--- a/single/sol/sol_forward.hpp
+++ b/single/sol/sol_forward.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2018-08-04 15:02:30.657205 UTC
-// This header was generated with sol v2.20.3 (revision daa9993)
+// Generated 2018-10-28 14:26:06.124383 UTC
+// This header was generated with sol v2.20.4 (revision a19a5a3)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_FORWARD_HPP

--- a/sol/load_result.hpp
+++ b/sol/load_result.hpp
@@ -122,7 +122,7 @@ namespace sol {
 
 		template <typename... Ret, typename... Args>
 		decltype(auto) call(Args&&... args) {
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 191200000
+#if !defined(__clang__) && defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 191200000
 			// MSVC is ass sometimes
 			return get<protected_function>().call<Ret...>(std::forward<Args>(args)...);
 #else

--- a/sol/proxy.hpp
+++ b/sol/proxy.hpp
@@ -126,7 +126,7 @@ namespace sol {
 
 		template <typename... Ret, typename... Args>
 		decltype(auto) call(Args&&... args) {
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 191200000
+#if !defined(__clang__) && defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 191200000
 			// MSVC is ass sometimes
 			return get<function>().call<Ret...>(std::forward<Args>(args)...);
 #else


### PR DESCRIPTION
If building with clang on Windows, it tries to imitate MSVC by specifying reasonable _MSC_VER defines.
This makes sol2 compile MSVC version of sol::proxy::call (without the "template" preffix) that is nevertheless not accepted by clang.

This commit fixes the problem by also checking if "__clang__" is defined.