### PR TITLE
Enable C++17 features when __cplusplus >= 201703.

### DIFF
--- a/include/sol/feature_test.hpp
+++ b/include/sol/feature_test.hpp
@@ -24,7 +24,7 @@
 #ifndef SOL_FEATURE_TEST_HPP
 #define SOL_FEATURE_TEST_HPP
 
-#if (defined(__cplusplus) && __cplusplus == 201703L) || (defined(_MSC_VER) && _MSC_VER > 1900 && ((defined(_HAS_CXX17) && _HAS_CXX17 == 1) || (defined(_MSVC_LANG) && (_MSVC_LANG > 201402L))))
+#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_MSC_VER) && _MSC_VER > 1900 && ((defined(_HAS_CXX17) && _HAS_CXX17 == 1) || (defined(_MSVC_LANG) && (_MSVC_LANG > 201402L))))
 #ifndef SOL_CXX17_FEATURES
 #define SOL_CXX17_FEATURES 1
 #endif // C++17 features macro


### PR DESCRIPTION
This will keep them enabled even when compiling with later
standards or experimental standards such as -std=c++2a.

Prior to this it was requiring strict equality.