### PR TITLE
Bug: constructing basic_reference<true> from basic_reference<false> doesn't pick main lua_State

### DIFF
--- a/include/sol/reference.hpp
+++ b/include/sol/reference.hpp
@@ -557,11 +557,11 @@ namespace sol {
 		}
 
 		basic_reference(const basic_reference<!main_only>& o) noexcept
-		: basic_reference(detail::pick_main_thread < main_only && !main_only > (o.lua_state(), o.lua_state()), o) {
+		: basic_reference(detail::pick_main_thread<main_only>(o.lua_state(), o.lua_state()), o) {
 		}
 
 		basic_reference(basic_reference<!main_only>&& o) noexcept
-		: stateless_reference(std::move(o)), luastate(detail::pick_main_thread<main_only && !main_only>(o.lua_state(), o.lua_state())) {
+		: stateless_reference(std::move(o)), luastate(detail::pick_main_thread<main_only>(o.lua_state(), o.lua_state())) {
 			o.luastate = nullptr;
 			o.ref = LUA_NOREF;
 		}

--- a/single/include/sol/sol.hpp
+++ b/single/include/sol/sol.hpp
@@ -9142,11 +9142,11 @@ namespace sol {
 		}
 
 		basic_reference(const basic_reference<!main_only>& o) noexcept
-		: basic_reference(detail::pick_main_thread < main_only && !main_only > (o.lua_state(), o.lua_state()), o) {
+		: basic_reference(detail::pick_main_thread<main_only>(o.lua_state(), o.lua_state()), o) {
 		}
 
 		basic_reference(basic_reference<!main_only>&& o) noexcept
-		: stateless_reference(std::move(o)), luastate(detail::pick_main_thread<main_only && !main_only>(o.lua_state(), o.lua_state())) {
+		: stateless_reference(std::move(o)), luastate(detail::pick_main_thread<main_only>(o.lua_state(), o.lua_state())) {
 			o.luastate = nullptr;
 			o.ref = LUA_NOREF;
 		}


### PR DESCRIPTION
Hello!

This PR fixes transferring references between main and non-main lua states. Let's consider the following example:

```cpp
// create main state and thread with its own sub-state
sol::state mainL;
sol::thread th = sol::thread::create(mainL);
sol::state_view threadL = th.state();

// add some non-nil variable
mainL["foo"] = 1;

// get non main reference to it
sol::reference ref = threadL["foo"];
assert(ref.lua_state() == threadL); // ok, as expected

// try to transfer to main 
sol::main_reference main_ref(ref);
assert(main_ref.lua_state() == mainL); // fails! main_ref.lua_state() == threadL
```

Let's check `sol::basic_reference` copy constructor called above:

```cpp
basic_reference(const basic_reference<!main_only>& o) noexcept
	: basic_reference(detail::pick_main_thread < main_only && !main_only > (o.lua_state(), o.lua_state()), o) {
}
```

First of all, `main_only && !main_only` is always false. Typical and **corrent** usage of `pick_main_thread` is `pick_main_thread<main_only && !r_main_only>`. 

In this ctor `r_main_only == !main_only`, so we should change code to `pick_main_thread<main_only && !!main_only>` or simply to `pick_main_thread<main_only>`:

```cpp
basic_reference(const basic_reference<!main_only>& o) noexcept
	: basic_reference(detail::pick_main_thread<main_only>(o.lua_state(), o.lua_state()), o) {
}
```

The same applies to move-ctor. 
