### PR TITLE
Uniform management of optional types (sol::optional, std::optional)

### DIFF
--- a/include/sol/stack_check_get_qualified.hpp
+++ b/include/sol/stack_check_get_qualified.hpp
@@ -57,9 +57,10 @@ namespace sol { namespace stack {
 		}
 	};
 
-	template <typename T>
-	struct qualified_getter<optional<T>> {
-		static optional<T> get(lua_State* L, int index, record& tracking) {
+	template <typename O>
+	struct qualified_getter<O, std::enable_if_t<meta::is_optional_v<O>>> {
+		static O get(lua_State* L, int index, record& tracking) {
+			using T = typename O::value_type;
 			if constexpr (is_lua_reference_v<T>) {
 				// actually check if it's none here, otherwise
 				// we'll have a none object inside an optional!
@@ -67,33 +68,19 @@ namespace sol { namespace stack {
 				if (!success) {
 					// expected type, actual type
 					tracking.use(static_cast<int>(success));
-					return nullopt;
+					return {};
 				}
 				return stack_detail::unchecked_get<T>(L, index, tracking);
 			}
 			else {
 				if (!check<T>(L, index, &no_panic)) {
 					tracking.use(static_cast<int>(!lua_isnone(L, index)));
-					return nullopt;
+					return {};
 				}
 				return stack_detail::unchecked_get<T>(L, index, tracking);
 			}
 		}
 	};
-
-#if defined(SOL_CXX17_FEATURES) && SOL_CXX17_FEATURES
-	template <typename T>
-	struct qualified_getter<std::optional<T>> {
-		static std::optional<T> get(lua_State* L, int index, record& tracking) {
-			if (!check<T>(L, index, no_panic)) {
-				tracking.use(static_cast<int>(!lua_isnone(L, index)));
-				return std::nullopt;
-			}
-			return stack_detail::unchecked_get<T>(L, index, tracking);
-		}
-	};
-#endif // C++17 features
-
 }} // namespace sol::stack
 
 #endif // SOL_STACK_CHECK_QUALIFIED_GET_HPP

--- a/include/sol/stack_check_get_unqualified.hpp
+++ b/include/sol/stack_check_get_unqualified.hpp
@@ -31,12 +31,9 @@
 
 #include <cstdlib>
 #include <cmath>
-#if defined(SOL_CXX17_FEATURES) && SOL_CXX17_FEATURES
-#include <optional>
 #if defined(SOL_STD_VARIANT) && SOL_STD_VARIANT
 #include <variant>
 #endif // variant
-#endif // C++17
 
 
 
@@ -129,22 +126,11 @@ namespace stack {
 		}
 	};
 
-	template <typename T>
-	struct unqualified_getter<optional<T>> {
-		static decltype(auto) get(lua_State* L, int index, record& tracking) {
+	template <typename O>
+	struct unqualified_getter<O, std::enable_if_t<meta::is_optional_v<O>>> {
+		static O get(lua_State* L, int index, record& tracking) {
+			using T = typename O::value_type;
 			return stack::unqualified_check_get<T>(L, index, no_panic, tracking);
-		}
-	};
-
-#if defined(SOL_CXX17_FEATURES) && SOL_CXX17_FEATURES
-	template <typename T>
-	struct unqualified_getter<std::optional<T>> {
-		static std::optional<T> get(lua_State* L, int index, record& tracking) {
-			if (!unqualified_check<T>(L, index, no_panic)) {
-				tracking.use(static_cast<int>(!lua_isnone(L, index)));
-				return std::nullopt;
-			}
-			return stack_detail::unchecked_unqualified_get<T>(L, index, tracking);
 		}
 	};
 
@@ -189,7 +175,6 @@ namespace stack {
 		}
 	};
 #endif // SOL_STD_VARIANT
-#endif // SOL_CXX17_FEATURES
 }
 } // namespace sol::stack
 

--- a/include/sol/stack_check_unqualified.hpp
+++ b/include/sol/stack_check_unqualified.hpp
@@ -31,12 +31,9 @@
 #include <functional>
 #include <utility>
 #include <cmath>
-#if defined(SOL_CXX17_FEATURES) && SOL_CXX17_FEATURES
-#include <optional>
 #if defined(SOL_STD_VARIANT) && SOL_STD_VARIANT
 #include <variant>
 #endif // SOL_STD_VARIANT
-#endif // SOL_CXX17_FEATURES
 
 namespace sol { namespace stack {
 	namespace stack_detail {
@@ -555,8 +552,9 @@ namespace sol { namespace stack {
 		}
 	};
 
-	template <typename T>
-	struct unqualified_checker<optional<T>, type::poly> {
+	template <typename O>
+	struct unqualified_checker<O, type::poly, std::enable_if_t<meta::is_optional_v<O>>> {
+		using T = typename O::value_type;
 		template <typename Handler>
 		static bool check(lua_State* L, int index, Handler&&, record& tracking) {
 			type t = type_of(L, index);
@@ -569,25 +567,6 @@ namespace sol { namespace stack {
 				return true;
 			}
 			return stack::unqualified_check<T>(L, index, no_panic, tracking);
-		}
-	};
-
-#if defined(SOL_CXX17_FEATURES) && SOL_CXX17_FEATURES
-
-	template <typename T>
-	struct unqualified_checker<std::optional<T>, type::poly> {
-		template <typename Handler>
-		static bool check(lua_State* L, int index, Handler&&, record& tracking) {
-			type t = type_of(L, index);
-			if (t == type::none) {
-				tracking.use(0);
-				return true;
-			}
-			if (t == type::lua_nil) {
-				tracking.use(1);
-				return true;
-			}
-			return stack::check<T>(L, index, no_panic, tracking);
 		}
 	};
 
@@ -629,8 +608,6 @@ namespace sol { namespace stack {
 	};
 
 #endif // SOL_STD_VARIANT
-
-#endif // SOL_CXX17_FEATURES
 }}     // namespace sol::stack
 
 #endif // SOL_STACK_CHECK_UNQUALIFIED_HPP

--- a/include/sol/stack_core.hpp
+++ b/include/sol/stack_core.hpp
@@ -35,6 +35,7 @@
 #include "stack_guard.hpp"
 #include "demangle.hpp"
 #include "forward_detail.hpp"
+#include "optional.hpp"
 
 #include <vector>
 #include <bitset>
@@ -42,9 +43,6 @@
 #include <string>
 #include <algorithm>
 #include <sstream>
-#if defined(SOL_CXX17_FEATURES) && SOL_CXX17_FEATURES
-#include <optional>
-#endif // C++17
 
 namespace sol {
 	namespace detail {
@@ -1193,12 +1191,7 @@ namespace sol {
 		template <typename T>
 		auto get(lua_State* L, int index, record& tracking) -> decltype(stack_detail::unchecked_get<T>(L, index, tracking)) {
 #if defined(SOL_SAFE_GETTER) && SOL_SAFE_GETTER
-			static constexpr bool is_op = meta::is_specialization_of_v<T, optional>
-#if defined(SOL_CXX17_FEATURES) && SOL_CXX17_FEATURES
-			     || meta::is_specialization_of_v<T, std::optional>
-#endif
-			     ;
-			if constexpr (is_op) {
+			if constexpr (meta::is_optional_v<T>) {
 				return stack_detail::unchecked_get<T>(L, index, tracking);
 			}
 			else {

--- a/single/include/sol/forward.hpp
+++ b/single/include/sol/forward.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2020-01-27 19:13:11.283155 UTC
-// This header was generated with sol v3.2.0 (revision 0c38fd1)
+// Generated 2020-01-28 20:44:48.314617 UTC
+// This header was generated with sol v3.2.0 (revision 903f4db0)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_FORWARD_HPP


### PR DESCRIPTION
Let's consider the following program:

```
#include <sol/sol.hpp>
#include <iostream>

template <typename T>
const char* f(T value) {
	return value.has_value() ? "fail" : "ok";
}

int main() {
	sol::state L;

	#define TEST(T) L.set_function("f", f<T>); std::cout << #T << ": " << static_cast<std::string>(L["f"]()) << "\n";

	TEST(sol::optional<int>);
	TEST(std::optional<int>);
	TEST(sol::optional<sol::table>);
	TEST(std::optional<sol::table>);
	TEST(sol::optional<sol::function>);
	TEST(std::optional<sol::function>);
	TEST(sol::optional<sol::object>);
	TEST(std::optional<sol::object>);

	return 0;
}
```

Current output is:

> sol::optional\<int\>: ok
> std::optional\<int\>: ok
> sol::optional\<sol::table\>: ok
> std::optional\<sol::table\>: ok
> sol::optional\<sol::function\>: ok
> std::optional\<sol::function\>: **fail**
> sol::optional\<sol::object\>: ok
> std::optional\<sol::object\>: **fail**

However, there should be no **fail** at all, because we call `f<T>` without an argument, so `value` must be `nullopt`, but it's not. It looks like `sol2` incorrectly handles some types wrapped in `std::optional`, although there is no problem with `sol::optional`.

This PR unifies management of both `sol::optional<T>` and `std::optional<T>` using `meta::is_optional` trait and thus fixes the previous example. I've also added some generic tests for both optionals.

The next step is to get rid of `meta::is_optional`. It can be replaced with some `is_detected`-based solution to completely remove dependency of `std::optional` and weird `#ifdef`s