### PR TITLE
Allow open_libraries() to accept any value category.

### DIFF
--- a/include/sol/state_view.hpp
+++ b/include/sol/state_view.hpp
@@ -112,7 +112,7 @@ namespace sol {
 
 		template <typename... Args>
 		void open_libraries(Args&&... args) {
-			static_assert(meta::all_same<lib, Args...>::value, "all types must be libraries");
+			static_assert(meta::all_same<lib, meta::unqualified_t<Args>...>::value, "all types must be libraries");
 			if constexpr (sizeof...(args) == 0) {
 				luaL_openlibs(L);
 				return;

--- a/single/include/sol/sol.hpp
+++ b/single/include/sol/sol.hpp
@@ -24338,7 +24338,7 @@ namespace sol {
 
 		template <typename... Args>
 		void open_libraries(Args&&... args) {
-			static_assert(meta::all_same<lib, Args...>::value, "all types must be libraries");
+			static_assert(meta::all_same<lib, meta::unqualified_t<Args>...>::value, "all types must be libraries");
 			if constexpr (sizeof...(args) == 0) {
 				luaL_openlibs(L);
 				return;


### PR DESCRIPTION
Currently, it accepts prvalue only, reference/cv don't pass `meta::all_same<lib, Args...>`
I found it useful to use it in a non-constexpr context