### PR TITLE
Reduce binary bloat in demangle implementation

### DIFF
--- a/include/sol/demangle.hpp
+++ b/include/sol/demangle.hpp
@@ -1,4 +1,4 @@
-// sol3 
+// sol3
 
 // The MIT License (MIT)
 
@@ -49,11 +49,9 @@ namespace detail {
 
 
 #if defined(__GNUC__) || defined(__clang__)
-	template <typename T, class seperator_mark = int>
-	inline std::string ctti_get_type_name() {
+	inline std::string ctti_get_type_name_from_sig(std::string name) {
 		// cardinal sins from MINGW
 		using namespace std;
-		std::string name = __PRETTY_FUNCTION__;
 		std::size_t start = name.find_first_of('[');
 		start = name.find_first_of('=', start);
 		std::size_t end = name.find_last_of(']');
@@ -83,10 +81,13 @@ namespace detail {
 
 		return name;
 	}
+
+	template <typename T, class seperator_mark = int>
+	inline std::string ctti_get_type_name() {
+		return ctti_get_type_name_from_sig(__PRETTY_FUNCTION__);
+	}
 #elif defined(_MSC_VER)
-	template <typename T>
-	std::string ctti_get_type_name() {
-		std::string name = __FUNCSIG__;
+	inline std::string ctti_get_type_name_from_sig(std::string name) {
 		std::size_t start = name.find("get_type_name");
 		if (start == std::string::npos)
 			start = 0;
@@ -117,6 +118,11 @@ namespace detail {
 
 		return name;
 	}
+
+	template <typename T>
+	std::string ctti_get_type_name() {
+		return ctti_get_type_name_from_sig(__FUNCSIG__);
+	}
 #else
 #error Compiler not supported for demangling
 #endif // compilers
@@ -127,9 +133,7 @@ namespace detail {
 		return realname;
 	}
 
-	template <typename T>
-	std::string short_demangle_once() {
-		std::string realname = ctti_get_type_name<T>();
+	inline std::string short_demangle_from_type_name(std::string realname) {
 		// This isn't the most complete but it'll do for now...?
 		static const std::array<std::string, 10> ops = {{"operator<", "operator<<", "operator<<=", "operator<=", "operator>", "operator>>", "operator>>=", "operator>=", "operator->", "operator->*"}};
 		int level = 0;
@@ -166,6 +170,12 @@ namespace detail {
 	}
 
 	template <typename T>
+	std::string short_demangle_once() {
+		std::string realname = ctti_get_type_name<T>();
+		return short_demangle_from_type_name(realname);
+	}
+
+	template <typename T>
 	const std::string& demangle() {
 		static const std::string d = demangle_once<T>();
 		return d;
@@ -176,7 +186,6 @@ namespace detail {
 		static const std::string d = short_demangle_once<T>();
 		return d;
 	}
-}
-} // namespace sol::detail
+}} // namespace sol::detail
 
 #endif // SOL_DEMANGLE_HPP

--- a/include/sol/demangle.hpp
+++ b/include/sol/demangle.hpp
@@ -186,6 +186,7 @@ namespace detail {
 		static const std::string d = short_demangle_once<T>();
 		return d;
 	}
-}} // namespace sol::detail
+}
+} // namespace sol::detail
 
 #endif // SOL_DEMANGLE_HPP

--- a/include/sol/stack_check_unqualified.hpp
+++ b/include/sol/stack_check_unqualified.hpp
@@ -38,9 +38,7 @@
 
 namespace sol { namespace stack {
 	namespace stack_detail {
-		template <typename T, bool poptable = true>
-		inline bool check_metatable(lua_State* L, int index = -2) {
-			const auto& metakey = usertype_traits<T>::metatable();
+		inline bool impl_check_metatable(lua_State* L, int index, const std::string& metakey, bool poptable) {
 			luaL_getmetatable(L, &metakey[0]);
 			const type expectedmetatabletype = static_cast<type>(lua_type(L, -1));
 			if (expectedmetatabletype != type::lua_nil) {
@@ -51,6 +49,11 @@ namespace sol { namespace stack {
 			}
 			lua_pop(L, 1);
 			return false;
+		}
+
+		template <typename T, bool poptable = true>
+		inline bool check_metatable(lua_State* L, int index = -2) {
+			return impl_check_metatable(L, index, usertype_traits<T>::metatable(), poptable);
 		}
 
 		template <type expected, int (*check_func)(lua_State*, int)>

--- a/include/sol/trampoline.hpp
+++ b/include/sol/trampoline.hpp
@@ -99,8 +99,8 @@ namespace sol {
 			return trampoline(L, f);
 		}
 #else
-		template <lua_CFunction f>
-		int static_trampoline(lua_State* L) {
+
+		inline int impl_static_trampoline(lua_State* L, lua_CFunction f) {
 #if defined(SOL_EXCEPTIONS_SAFE_PROPAGATION) && !defined(SOL_LUAJIT)
 			return f(L);
 
@@ -119,7 +119,7 @@ namespace sol {
 			}
 #if !defined(SOL_EXCEPTIONS_SAFE_PROPAGATION)
 			// LuaJIT cannot have the catchall when the safe propagation is on
-			// but LuaJIT will swallow all C++ errors 
+			// but LuaJIT will swallow all C++ errors
 			// if we don't at least catch std::exception ones
 			catch (...) {
 				call_exception_handler(L, optional<const std::exception&>(nullopt), "caught (...) exception");
@@ -127,6 +127,11 @@ namespace sol {
 #endif // LuaJIT cannot have the catchall, but we must catch std::exceps for it
 			return lua_error(L);
 #endif // Safe exceptions
+		}
+
+		template <lua_CFunction f>
+		int static_trampoline(lua_State* L) {
+			return impl_static_trampoline(L, f);
 		}
 
 #ifdef SOL_NOEXCEPT_FUNCTION_TYPE

--- a/single/include/sol/forward.hpp
+++ b/single/include/sol/forward.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2020-06-06 16:05:17.750133 UTC
-// This header was generated with sol v3.2.1 (revision e09d2ff)
+// Generated 2020-06-18 21:54:34.473478 UTC
+// This header was generated with sol v3.2.1 (revision 62a831cd)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_FORWARD_HPP

--- a/single/include/sol/forward.hpp
+++ b/single/include/sol/forward.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2020-06-18 21:54:34.473478 UTC
-// This header was generated with sol v3.2.1 (revision 62a831cd)
+// Generated 2020-06-18 22:17:10.413702 UTC
+// This header was generated with sol v3.2.1 (revision 162fdd74)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_FORWARD_HPP

--- a/single/include/sol/forward.hpp
+++ b/single/include/sol/forward.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2020-06-18 22:17:10.413702 UTC
-// This header was generated with sol v3.2.1 (revision 162fdd74)
+// Generated 2020-06-20 04:08:19.579717 UTC
+// This header was generated with sol v3.2.1 (revision 5e40ef09)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_FORWARD_HPP

--- a/single/include/sol/sol.hpp
+++ b/single/include/sol/sol.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2020-06-18 22:17:10.286043 UTC
-// This header was generated with sol v3.2.1 (revision 162fdd74)
+// Generated 2020-06-20 04:08:19.416569 UTC
+// This header was generated with sol v3.2.1 (revision 5e40ef09)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_HPP
@@ -7476,8 +7476,8 @@ namespace sol {
 			return trampoline(L, f);
 		}
 #else
-		template <lua_CFunction f>
-		int static_trampoline(lua_State* L) {
+
+		inline int impl_static_trampoline(lua_State* L, lua_CFunction f) {
 #if defined(SOL_EXCEPTIONS_SAFE_PROPAGATION) && !defined(SOL_LUAJIT)
 			return f(L);
 
@@ -7496,7 +7496,7 @@ namespace sol {
 			}
 #if !defined(SOL_EXCEPTIONS_SAFE_PROPAGATION)
 			// LuaJIT cannot have the catchall when the safe propagation is on
-			// but LuaJIT will swallow all C++ errors 
+			// but LuaJIT will swallow all C++ errors
 			// if we don't at least catch std::exception ones
 			catch (...) {
 				call_exception_handler(L, optional<const std::exception&>(nullopt), "caught (...) exception");
@@ -7504,6 +7504,11 @@ namespace sol {
 #endif // LuaJIT cannot have the catchall, but we must catch std::exceps for it
 			return lua_error(L);
 #endif // Safe exceptions
+		}
+
+		template <lua_CFunction f>
+		int static_trampoline(lua_State* L) {
+			return impl_static_trampoline(L, f);
 		}
 
 #ifdef SOL_NOEXCEPT_FUNCTION_TYPE
@@ -10671,9 +10676,7 @@ namespace sol {
 
 namespace sol { namespace stack {
 	namespace stack_detail {
-		template <typename T, bool poptable = true>
-		inline bool check_metatable(lua_State* L, int index = -2) {
-			const auto& metakey = usertype_traits<T>::metatable();
+		inline bool impl_check_metatable(lua_State* L, int index, const std::string& metakey, bool poptable) {
 			luaL_getmetatable(L, &metakey[0]);
 			const type expectedmetatabletype = static_cast<type>(lua_type(L, -1));
 			if (expectedmetatabletype != type::lua_nil) {
@@ -10684,6 +10687,11 @@ namespace sol { namespace stack {
 			}
 			lua_pop(L, 1);
 			return false;
+		}
+
+		template <typename T, bool poptable = true>
+		inline bool check_metatable(lua_State* L, int index = -2) {
+			return impl_check_metatable(L, index, usertype_traits<T>::metatable(), poptable);
 		}
 
 		template <type expected, int (*check_func)(lua_State*, int)>

--- a/single/include/sol/sol.hpp
+++ b/single/include/sol/sol.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2020-06-18 21:54:34.347814 UTC
-// This header was generated with sol v3.2.1 (revision 62a831cd)
+// Generated 2020-06-18 22:17:10.286043 UTC
+// This header was generated with sol v3.2.1 (revision 162fdd74)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_HPP
@@ -7757,7 +7757,8 @@ namespace detail {
 		static const std::string d = short_demangle_once<T>();
 		return d;
 	}
-}} // namespace sol::detail
+}
+} // namespace sol::detail
 
 // end of sol/demangle.hpp
 

--- a/single/include/sol/sol.hpp
+++ b/single/include/sol/sol.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2020-06-06 16:05:12.150007 UTC
-// This header was generated with sol v3.2.1 (revision e09d2ff)
+// Generated 2020-06-18 21:54:34.347814 UTC
+// This header was generated with sol v3.2.1 (revision 62a831cd)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_HPP
@@ -7620,11 +7620,9 @@ namespace detail {
 		"`anonymous namespace'" } };
 
 #if defined(__GNUC__) || defined(__clang__)
-	template <typename T, class seperator_mark = int>
-	inline std::string ctti_get_type_name() {
+	inline std::string ctti_get_type_name_from_sig(std::string name) {
 		// cardinal sins from MINGW
 		using namespace std;
-		std::string name = __PRETTY_FUNCTION__;
 		std::size_t start = name.find_first_of('[');
 		start = name.find_first_of('=', start);
 		std::size_t end = name.find_last_of(']');
@@ -7654,10 +7652,13 @@ namespace detail {
 
 		return name;
 	}
+
+	template <typename T, class seperator_mark = int>
+	inline std::string ctti_get_type_name() {
+		return ctti_get_type_name_from_sig(__PRETTY_FUNCTION__);
+	}
 #elif defined(_MSC_VER)
-	template <typename T>
-	std::string ctti_get_type_name() {
-		std::string name = __FUNCSIG__;
+	inline std::string ctti_get_type_name_from_sig(std::string name) {
 		std::size_t start = name.find("get_type_name");
 		if (start == std::string::npos)
 			start = 0;
@@ -7688,6 +7689,11 @@ namespace detail {
 
 		return name;
 	}
+
+	template <typename T>
+	std::string ctti_get_type_name() {
+		return ctti_get_type_name_from_sig(__FUNCSIG__);
+	}
 #else
 #error Compiler not supported for demangling
 #endif // compilers
@@ -7698,9 +7704,7 @@ namespace detail {
 		return realname;
 	}
 
-	template <typename T>
-	std::string short_demangle_once() {
-		std::string realname = ctti_get_type_name<T>();
+	inline std::string short_demangle_from_type_name(std::string realname) {
 		// This isn't the most complete but it'll do for now...?
 		static const std::array<std::string, 10> ops = {{"operator<", "operator<<", "operator<<=", "operator<=", "operator>", "operator>>", "operator>>=", "operator>=", "operator->", "operator->*"}};
 		int level = 0;
@@ -7737,6 +7741,12 @@ namespace detail {
 	}
 
 	template <typename T>
+	std::string short_demangle_once() {
+		std::string realname = ctti_get_type_name<T>();
+		return short_demangle_from_type_name(realname);
+	}
+
+	template <typename T>
 	const std::string& demangle() {
 		static const std::string d = demangle_once<T>();
 		return d;
@@ -7747,8 +7757,7 @@ namespace detail {
 		static const std::string d = short_demangle_once<T>();
 		return d;
 	}
-}
-} // namespace sol::detail
+}} // namespace sol::detail
 
 // end of sol/demangle.hpp
 

--- a/single/single.py
+++ b/single/single.py
@@ -39,7 +39,7 @@ forward_single_file = ''
 single_file = os.path.normpath(args.output[0])
 
 if len(args.output) > 1:
-	forward_single_file = args.output[1]
+	forward_single_file = os.path.normpath(args.output[1])
 else:
 	a, b = os.path.splitext(single_file)
 	a = os.path.dirname(single_file)
@@ -49,7 +49,7 @@ else:
 single_file_dir = os.path.dirname(single_file)
 forward_single_file_dir = os.path.dirname(forward_single_file)
 
-script_path = args.input
+script_path = os.path.normpath(args.input)
 working_dir = os.getcwd()
 os.chdir(script_path)
 


### PR DESCRIPTION
ctti_get_type_name is currently ~1kb per instantiation on an optimized build, which adds up quickly with a large number of bindings. This moves the bulk of the implementation into a non-template function to reduce the amount of duplicated code.

Built and tested with MSVC only. I gave my best guess for ifdef'd gcc/clang code but I'm not set up to build with that toolchain at the moment so will need someone to review.