### PR TITLE
no_constructpr, variable name is_const -> ret_is_const

### DIFF
--- a/include/sol/call.hpp
+++ b/include/sol/call.hpp
@@ -524,8 +524,8 @@ namespace sol {
 					else {
 						using traits_type = lua_bind_traits<F>;
 						using return_type = typename traits_type::return_type;
-						constexpr bool is_const = std::is_const_v<std::remove_reference_t<return_type>>;
-						if constexpr (is_const) {
+						constexpr bool ret_is_const = std::is_const_v<std::remove_reference_t<return_type>>;
+						if constexpr (ret_is_const) {
 							(void)fx;
 							(void)detail::swallow{ 0, (static_cast<void>(args), 0)... };
 							return luaL_error(L, "sol: cannot write to a readonly (const) variable");

--- a/include/sol/function_types.hpp
+++ b/include/sol/function_types.hpp
@@ -497,7 +497,7 @@ namespace sol {
 
 		template <typename T>
 		struct unqualified_pusher<detail::tagged<T, no_construction>> {
-			static int push(lua_State* L, no_construction) {
+			static int push(lua_State* L, detail::tagged<T, no_construction>) {
 				lua_CFunction cf = &function_detail::no_construction_error;
 				return stack::push(L, cf);
 			}


### PR DESCRIPTION
`is_const` will get some strange messages in VS 2019
maybe it is conflicted with `std::is_const`