### PR TITLE
fix bug in checking for const in push_reference

### DIFF
--- a/include/sol/stack_core.hpp
+++ b/include/sol/stack_core.hpp
@@ -943,7 +943,7 @@ namespace sol {
 			template <typename T, typename Arg, typename... Args>
 			int push_reference(lua_State* L, Arg&& arg, Args&&... args) {
 				using use_reference_tag = meta::all<std::is_lvalue_reference<T>,
-				     meta::neg<std::is_const<T>>,
+				     meta::neg<std::is_const<std::remove_reference_t<T>>>,
 				     meta::neg<is_lua_primitive<meta::unqualified_t<T>>>,
 				     meta::neg<is_unique_usertype<meta::unqualified_t<T>>>>;
 				using Tr = meta::conditional_t<use_reference_tag::value, detail::as_reference_tag, meta::unqualified_t<T>>;


### PR DESCRIPTION
`std::is_const<T>` will always be false if `std::is_lvalue_reference<T>` is true, we first have to strip off the reference to look at the const-ness. See https://en.cppreference.com/w/cpp/types/is_const