### PR TITLE
Fix typos in configuration macros.

### DIFF
--- a/include/sol/version.hpp
+++ b/include/sol/version.hpp
@@ -193,7 +193,7 @@
 	#if SOL_ALL_SAFETIES_ON != 0
 		#define SOL_ALL_SAFETIES_ON_I_ SOL_ON
 	#else
-		#define SOL_ALL_SAFETIES_ON_I_ SOL_FF
+		#define SOL_ALL_SAFETIES_ON_I_ SOL_OFF
 	#endif
 #else
 	#define SOL_ALL_SAFETIES_ON_I_ SOL_DEFAULT_OFF

--- a/single/include/sol/forward.hpp
+++ b/single/include/sol/forward.hpp
@@ -199,7 +199,7 @@
 	#if SOL_ALL_SAFETIES_ON != 0
 		#define SOL_ALL_SAFETIES_ON_I_ SOL_ON
 	#else
-		#define SOL_ALL_SAFETIES_ON_I_ SOL_FF
+		#define SOL_ALL_SAFETIES_ON_I_ SOL_OFF
 	#endif
 #else
 	#define SOL_ALL_SAFETIES_ON_I_ SOL_DEFAULT_OFF

--- a/single/include/sol/sol.hpp
+++ b/single/include/sol/sol.hpp
@@ -199,7 +199,7 @@
 	#if SOL_ALL_SAFETIES_ON != 0
 		#define SOL_ALL_SAFETIES_ON_I_ SOL_ON
 	#else
-		#define SOL_ALL_SAFETIES_ON_I_ SOL_FF
+		#define SOL_ALL_SAFETIES_ON_I_ SOL_OFF
 	#endif
 #else
 	#define SOL_ALL_SAFETIES_ON_I_ SOL_DEFAULT_OFF


### PR DESCRIPTION
Fixes a few typos in the recent configuration macros.

Fixes my report here: https://github.com/ThePhD/sol2/issues/1057