### PR TITLE
Add override qualifier to bad_optional_access::what()

### DIFF
--- a/include/sol/optional_implementation.hpp
+++ b/include/sol/optional_implementation.hpp
@@ -657,7 +657,7 @@ namespace sol {
 	class bad_optional_access : public std::exception {
 	public:
 		bad_optional_access() = default;
-		const char* what() const noexcept {
+		const char* what() const noexcept override {
 			return "Optional has no value";
 		}
 	};

--- a/single/include/sol/sol.hpp
+++ b/single/include/sol/sol.hpp
@@ -4598,7 +4598,7 @@ namespace sol {
 	class bad_optional_access : public std::exception {
 	public:
 		bad_optional_access() = default;
-		const char* what() const noexcept {
+		const char* what() const noexcept override {
 			return "Optional has no value";
 		}
 	};


### PR DESCRIPTION
This fixes a GCC -Wsuggest-override warning (and the equivalent clang warning).  It was encountered in MAME where we build with warnings as errors.