### PR TITLE
Fix aligned memory allocation

### DIFF
--- a/include/sol/stack_core.hpp
+++ b/include/sol/stack_core.hpp
@@ -78,7 +78,7 @@ namespace sol {
 #endif
 		}
 
-		inline std::uintptr_t align(std::size_t alignment, std::uintptr_t ptr, std::size_t& space) {
+		constexpr std::uintptr_t align(std::size_t alignment, std::uintptr_t ptr, std::size_t& space) {
 			// this handles arbitrary alignments...
 			// make this into a power-of-2-only?
 			// actually can't: this is a C++14-compatible framework,
@@ -94,13 +94,13 @@ namespace sol {
 			return reinterpret_cast<void*>(align(alignment, reinterpret_cast<std::uintptr_t>(ptr), space));
 		}
 
-		inline std::uintptr_t align_one(std::size_t alignment, std::size_t size, std::uintptr_t target_alignment) {
+		constexpr std::uintptr_t align_one(std::size_t alignment, std::size_t size, std::uintptr_t target_alignment) {
 			std::size_t space = (std::numeric_limits<std::size_t>::max)();
 			return align(alignment, target_alignment, space) + size;
 		}
 
 		template <typename... Args>
-		std::size_t aligned_space_for(std::uintptr_t alignment) {
+		constexpr std::size_t aligned_space_for(std::uintptr_t alignment) {
 			std::uintptr_t start = alignment;
 			(void)detail::swallow { int {}, (alignment = align_one(std::alignment_of_v<Args>, sizeof(Args), alignment), int {})... };
 			return static_cast<std::size_t>(alignment - start);
@@ -219,8 +219,8 @@ namespace sol {
 				T** pointerpointer = static_cast<T**>(alloc_newuserdata(L, sizeof(T*)));
 				return pointerpointer;
 			}
-			static const std::size_t initial_size = aligned_space_for<T*>(0x0);
-			static const std::size_t misaligned_size = aligned_space_for<T*>(0x1);
+			constexpr std::size_t initial_size = aligned_space_for<T*>(0x0);
+			constexpr std::size_t misaligned_size = aligned_space_for<T*>(0x1);
 
 			std::size_t allocated_size = initial_size;
 			void* unadjusted = alloc_newuserdata(L, initial_size);
@@ -331,8 +331,8 @@ namespace sol {
 			compilers are optimized for aligned reads/writes
 			(and clang will barf UBsan errors on us for not being aligned)
 			*/
-			static const std::size_t initial_size = aligned_space_for<T*, T>(0x0);
-			static const std::size_t misaligned_size = aligned_space_for<T*, T>(0x1);
+			constexpr std::size_t initial_size = aligned_space_for<T*, T>(0x0);
+			constexpr std::size_t misaligned_size = aligned_space_for<T*, T>(0x1);
 
 			void* pointer_adjusted;
 			void* data_adjusted;
@@ -382,8 +382,8 @@ namespace sol {
 				return mem;
 			}
 
-			static const std::size_t initial_size = aligned_space_for<T*, unique_destructor, unique_tag, Real>(0x0);
-			static const std::size_t misaligned_size = aligned_space_for<T*, unique_destructor, unique_tag, Real>(0x1);
+			constexpr std::size_t initial_size = aligned_space_for<T*, unique_destructor, unique_tag, Real>(0x0);
+			constexpr std::size_t misaligned_size = aligned_space_for<T*, unique_destructor, unique_tag, Real>(0x1);
 
 			void* pointer_adjusted;
 			void* dx_adjusted;
@@ -450,8 +450,8 @@ namespace sol {
 				return pointer;
 			}
 
-			static const std::size_t initial_size = aligned_space_for<T>(0x0);
-			static const std::size_t misaligned_size = aligned_space_for<T>(0x1);
+			constexpr std::size_t initial_size = aligned_space_for<T>(0x0);
+			constexpr std::size_t misaligned_size = aligned_space_for<T>(0x1);
 
 			std::size_t allocated_size = initial_size;
 			void* unadjusted = alloc_newuserdata(L, allocated_size);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,8 @@ function(sol2_create_basic_test test_target_name target_sol)
 		PRIVATE ${target_sol})
 	target_compile_definitions(${test_target_name}
 		PRIVATE SOL_ALL_SAFETIES_ON=1)
+	target_compile_definitions(${test_target_name}
+		PRIVATE SOL_TESTS_SIZEOF_VOID_P=${CMAKE_SIZEOF_VOID_P})
 endfunction()
 
 add_subdirectory(inclusion)

--- a/tests/regression_tests/simple/source/1192 - incorrect alignment calculation.cpp
+++ b/tests/regression_tests/simple/source/1192 - incorrect alignment calculation.cpp
@@ -2,7 +2,7 @@
 
 #if SOL_TESTS_SIZEOF_VOID_P == 4
 
-inline namespace sol2_regression_test_XXXX {
+inline namespace sol2_regression_test_1192 {
 	struct Test {
 		std::uint64_t dummy;
 	};
@@ -10,9 +10,9 @@ inline namespace sol2_regression_test_XXXX {
 	struct alignas(1024) Test2 {
 		char dummy[1024];
 	};
-} // namespace sol2_regression_test_XXXX
+} // namespace sol2_regression_test_1192
 
-unsigned int regression_XXXX() {
+unsigned int regression_1192() {
 	sol::state lua;
 
 	static_assert(sizeof(Test) == 8);
@@ -20,7 +20,7 @@ unsigned int regression_XXXX() {
 	static_assert(sizeof(Test*) == 4);
 	static_assert(alignof(Test*) == 4);
 
-	/// [sol2] An error occurred and panic has been invoked: aligned allocation of userdata block (data section) for 'sol2_regression_test_XXXX::Test' failed
+	/// [sol2] An error occurred and panic has been invoked: aligned allocation of userdata block (data section) for 'sol2_regression_test_1192::Test' failed
 	/// Note: may not panic depending on alignment of local variable `alignment_shim` in sol::detail::aligned_space_for
 	lua["test"] = Test {};
 
@@ -33,7 +33,7 @@ unsigned int regression_XXXX() {
 
 #else
 
-unsigned int regression_XXXX() {
+unsigned int regression_1192() {
 	return 0;
 }
 

--- a/tests/regression_tests/simple/source/XXXX - incorrect alignment calculation.cpp
+++ b/tests/regression_tests/simple/source/XXXX - incorrect alignment calculation.cpp
@@ -6,6 +6,10 @@ inline namespace sol2_regression_test_XXXX {
 	struct Test {
 		std::uint64_t dummy;
 	};
+
+	struct alignas(1024) Test2 {
+		char dummy[1024];
+	};
 } // namespace sol2_regression_test_XXXX
 
 unsigned int regression_XXXX() {
@@ -19,6 +23,10 @@ unsigned int regression_XXXX() {
 	/// [sol2] An error occurred and panic has been invoked: aligned allocation of userdata block (data section) for 'sol2_regression_test_XXXX::Test' failed
 	/// Note: may not panic depending on alignment of local variable `alignment_shim` in sol::detail::aligned_space_for
 	lua["test"] = Test {};
+
+	// Test also unique and over-aligned userdata
+	lua["test"] = std::make_unique<Test>();
+	lua["test"] = Test2 {};
 
 	return 0;
 }

--- a/tests/regression_tests/simple/source/XXXX - incorrect alignment calculation.cpp
+++ b/tests/regression_tests/simple/source/XXXX - incorrect alignment calculation.cpp
@@ -1,0 +1,32 @@
+#include <sol/sol.hpp>
+
+#if SOL_TESTS_SIZEOF_VOID_P == 4
+
+inline namespace sol2_regression_test_XXXX {
+	struct Test {
+		std::uint64_t dummy;
+	};
+} // namespace sol2_regression_test_XXXX
+
+unsigned int regression_XXXX() {
+	sol::state lua;
+
+	static_assert(sizeof(Test) == 8);
+	static_assert(alignof(Test) == 8);
+	static_assert(sizeof(Test*) == 4);
+	static_assert(alignof(Test*) == 4);
+
+	/// [sol2] An error occurred and panic has been invoked: aligned allocation of userdata block (data section) for 'sol2_regression_test_XXXX::Test' failed
+	/// Note: may not panic depending on alignment of local variable `alignment_shim` in sol::detail::aligned_space_for
+	lua["test"] = Test {};
+
+	return 0;
+}
+
+#else
+
+unsigned int regression_XXXX() {
+	return 0;
+}
+
+#endif

--- a/tests/regression_tests/simple/source/main.cpp
+++ b/tests/regression_tests/simple/source/main.cpp
@@ -10,9 +10,10 @@ extern unsigned int regression_1087();
 extern unsigned int regression_1095();
 extern unsigned int regression_1096();
 extern unsigned int regression_1149();
+extern unsigned int regression_XXXX();
 
 static f_ptr* const regression_tests_regressions[]
-     = { &regression_1008, &regression_1000, &regression_1067, &regression_1072, &regression_1087, &regression_1095, &regression_1096, &regression_1149 };
+     = { &regression_1008, &regression_1000, &regression_1067, &regression_1072, &regression_1087, &regression_1095, &regression_1096, &regression_1149, &regression_XXXX };
 static const int regression_tests_sizeof_regressions = sizeof(regression_tests_regressions) / sizeof(regression_tests_regressions[0]);
 
 int trampoline(f_ptr* f) {

--- a/tests/regression_tests/simple/source/main.cpp
+++ b/tests/regression_tests/simple/source/main.cpp
@@ -10,10 +10,10 @@ extern unsigned int regression_1087();
 extern unsigned int regression_1095();
 extern unsigned int regression_1096();
 extern unsigned int regression_1149();
-extern unsigned int regression_XXXX();
+extern unsigned int regression_1192();
 
 static f_ptr* const regression_tests_regressions[]
-     = { &regression_1008, &regression_1000, &regression_1067, &regression_1072, &regression_1087, &regression_1095, &regression_1096, &regression_1149, &regression_XXXX };
+     = { &regression_1008, &regression_1000, &regression_1067, &regression_1072, &regression_1087, &regression_1095, &regression_1096, &regression_1149, &regression_1192 };
 static const int regression_tests_sizeof_regressions = sizeof(regression_tests_regressions) / sizeof(regression_tests_regressions[0]);
 
 int trampoline(f_ptr* f) {


### PR DESCRIPTION
Closes #1192 

- Reworked `sol::detail::aligned_space_for<Ts...>`
  - If no type is over-aligned (`alignof(Ts) <= alignof(std::max_align_t) for all Ts...`), calculate maximum possible required size assuming that allocator can return absolutely any address
  - Otherwise assume that every single type in pack has initial address `0x1` (the worst alignment)
  - Make it `constexpr`
- Always do only one allocation with required memory size. "aligned allocation failed" error should never happen anymore
- Remove unused arguments/variables (it was probably a legacy code)