### PR TITLE
Added FFI enabled check

### DIFF
--- a/include/sol/compatibility/lua_version.hpp
+++ b/include/sol/compatibility/lua_version.hpp
@@ -70,6 +70,14 @@
 	#define SOL_LUAJIT_VERSION_I_ 0
 #endif
 
+#if defined(SOL_LUAJIT_FFI_DISABLED)
+	#define SOL_LUAJIT_FFI_DISABLED_I_ SOL_ON
+#elif defined(LUAJIT_DISABLE_FFI)
+	#define SOL_LUAJIT_FFI_DISABLED_I_ SOL_ON
+#else
+	#define SOL_LUAJIT_FFI_DISABLED_I_ SOL_DEFAULT_OFF
+#endif
+
 #if defined(MOONJIT_VERSION)
 	#define SOL_USE_MOONJIT_I_ SOL_ON
 #else

--- a/include/sol/state_view.hpp
+++ b/include/sol/state_view.hpp
@@ -189,7 +189,7 @@ namespace sol {
 #endif // Lua 5.3+ only
 						break;
 					case lib::ffi:
-#if SOL_IS_ON(SOL_USE_LUAJIT_I_)
+#if SOL_IS_ON(SOL_USE_LUAJIT_I_) && SOL_IS_OFF(SOL_LUAJIT_FFI_DISABLED_I_)
 						luaL_requiref(L, "ffi", luaopen_ffi, 1);
 						lua_pop(L, 1);
 #endif // LuaJIT only


### PR DESCRIPTION
Fixes "undefined reference" error if LuaJIT is built with FFI disabled.