### PR TITLE
Fix compile error when registering new user types with operator()

### DIFF
--- a/include/sol/bind_traits.hpp
+++ b/include/sol/bind_traits.hpp
@@ -31,7 +31,7 @@
 namespace sol { namespace meta {
 	namespace meta_detail {
 		template <typename F>
-		using detect_deducible_signature = decltype(&F::operator(), void());
+		using detect_deducible_signature = decltype(&F::operator());
 	} // namespace meta_detail
 
 	template <typename F>


### PR DESCRIPTION
Compiling with the latest develop branch, the following would fail to compile (tested in MSVC 2019):

```
#define SOL_ALL_SAFETIES_ON 1
#include <sol/sol.hpp>

struct Ptr
{
	int* operator()() { return nullptr; }
	const int* operator()() const { return nullptr; }
};

int main()
{
	sol::state lua;
	lua.new_usertype<Ptr>("Ptr");
	return 0;
}
```