### PR TITLE
Fixed: `std::cout` not found on msvc

### DIFF
--- a/tests/regression_tests/simple/source/1144 - type destructed from non-destructed memory.cpp
+++ b/tests/regression_tests/simple/source/1144 - type destructed from non-destructed memory.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <sol/sol.hpp>
 
 inline namespace sol2_regression_test_1144 {


### PR DESCRIPTION
I got that error (`std::cout` doesnt exist) while trying to build `develop` branch with MSVC (2022) after having added the regression tests to the `build2` package. Could be fixed some other ways.
