### PR TITLE
Fixed double deletion of "const reference" usertypes returned from functions

### DIFF
--- a/cmake/Modules/FindCatch.cmake
+++ b/cmake/Modules/FindCatch.cmake
@@ -28,7 +28,7 @@ include(Common/Core)
 if (Catch_FIND_VERSION)
 	set(catch_version ${Catch_FIND_VERSION})
 else()
-	set(catch_version 2.11.1)
+	set(catch_version 2.13.8)
 endif()
 
 set(catch_lib catch_lib_${catch_version})

--- a/examples/source/usertype_bitfields.cpp
+++ b/examples/source/usertype_bitfields.cpp
@@ -101,7 +101,7 @@ namespace itsy_bitsy {
 #pragma pack(1)
 struct flags_t {
 #else
-struct __attribute__((packed, aligned(1))) flags_t {
+struct __attribute__((packed, aligned(4))) flags_t {
 #endif
 	uint8_t C : 1;
 	uint8_t N : 1;

--- a/include/sol/stack_core.hpp
+++ b/include/sol/stack_core.hpp
@@ -960,7 +960,6 @@ namespace sol {
 			template <typename T, typename Arg, typename... Args>
 			int push_reference(lua_State* L, Arg&& arg, Args&&... args) {
 				using use_reference_tag = meta::all<std::is_lvalue_reference<T>,
-				     meta::neg<std::is_const<std::remove_reference_t<T>>>,
 				     meta::neg<is_lua_primitive<meta::unqualified_t<T>>>,
 				     meta::neg<is_unique_usertype<meta::unqualified_t<T>>>>;
 				using Tr = meta::conditional_t<use_reference_tag::value, detail::as_reference_tag, meta::unqualified_t<T>>;

--- a/include/sol/state_view.hpp
+++ b/include/sol/state_view.hpp
@@ -709,8 +709,8 @@ namespace sol {
 		}
 
 		// Returns the old GC mode. Check support using the supports_gc_mode function.
-		gc_mode change_gc_mode_generational(int minor_multiplier, int major_multiplier) {
 #if SOL_LUA_VESION_I_ >= 504
+		gc_mode change_gc_mode_generational(int minor_multiplier, int major_multiplier) {
 			// "What does this shit mean?"
 			// http://www.lua.org/manual/5.4/manual.html#2.5.2
 			int old_mode = lua_gc(lua_state(), LUA_GCGEN, minor_multiplier, major_multiplier);
@@ -720,9 +720,13 @@ namespace sol {
 			else if (old_mode == LUA_GCINC) {
 				return gc_mode::incremental;
 			}
-#endif
 			return gc_mode::default_value;
 		}
+#else
+		gc_mode change_gc_mode_generational(int, int) {
+			return gc_mode::default_value;
+		}
+#endif
 
 		operator lua_State*() const {
 			return lua_state();

--- a/single/include/sol/config.hpp
+++ b/single/include/sol/config.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2020-11-19 21:39:27.536445 UTC
-// This header was generated with sol v3.2.3 (revision 62804667)
+// Generated 2022-06-01 18:18:07.154168 UTC
+// This header was generated with sol v3.2.3 (revision c2c8225c)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_CONFIG_HPP

--- a/single/include/sol/config.hpp
+++ b/single/include/sol/config.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2022-06-01 18:18:07.154168 UTC
-// This header was generated with sol v3.2.3 (revision c2c8225c)
+// Generated 2022-06-01 18:20:25.587024 UTC
+// This header was generated with sol v3.2.3 (revision 898a4ba9)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_CONFIG_HPP

--- a/single/include/sol/forward.hpp
+++ b/single/include/sol/forward.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2022-06-01 18:18:07.152171 UTC
-// This header was generated with sol v3.2.3 (revision c2c8225c)
+// Generated 2022-06-01 18:20:25.585052 UTC
+// This header was generated with sol v3.2.3 (revision 898a4ba9)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_FORWARD_HPP

--- a/single/include/sol/forward.hpp
+++ b/single/include/sol/forward.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2020-11-19 21:39:27.514445 UTC
-// This header was generated with sol v3.2.3 (revision 62804667)
+// Generated 2022-06-01 18:18:07.152171 UTC
+// This header was generated with sol v3.2.3 (revision c2c8225c)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_FORWARD_HPP

--- a/single/include/sol/sol.hpp
+++ b/single/include/sol/sol.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2022-06-01 18:18:07.084763 UTC
-// This header was generated with sol v3.2.3 (revision c2c8225c)
+// Generated 2022-06-01 18:20:25.518534 UTC
+// This header was generated with sol v3.2.3 (revision 898a4ba9)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_HPP
@@ -10765,7 +10765,6 @@ namespace sol {
 			template <typename T, typename Arg, typename... Args>
 			int push_reference(lua_State* L, Arg&& arg, Args&&... args) {
 				using use_reference_tag = meta::all<std::is_lvalue_reference<T>,
-				     meta::neg<std::is_const<std::remove_reference_t<T>>>,
 				     meta::neg<is_lua_primitive<meta::unqualified_t<T>>>,
 				     meta::neg<is_unique_usertype<meta::unqualified_t<T>>>>;
 				using Tr = meta::conditional_t<use_reference_tag::value, detail::as_reference_tag, meta::unqualified_t<T>>;

--- a/single/include/sol/sol.hpp
+++ b/single/include/sol/sol.hpp
@@ -20,8 +20,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2020-11-19 21:39:26.848444 UTC
-// This header was generated with sol v3.2.3 (revision 62804667)
+// Generated 2022-06-01 18:18:07.084763 UTC
+// This header was generated with sol v3.2.3 (revision c2c8225c)
 // https://github.com/ThePhD/sol2
 
 #ifndef SOL_SINGLE_INCLUDE_HPP
@@ -25779,8 +25779,8 @@ namespace sol {
 		}
 
 		// Returns the old GC mode. Check support using the supports_gc_mode function.
-		gc_mode change_gc_mode_generational(int minor_multiplier, int major_multiplier) {
 #if SOL_LUA_VESION_I_ >= 504
+		gc_mode change_gc_mode_generational(int minor_multiplier, int major_multiplier) {
 			// "What does this shit mean?"
 			// http://www.lua.org/manual/5.4/manual.html#2.5.2
 			int old_mode = lua_gc(lua_state(), LUA_GCGEN, minor_multiplier, major_multiplier);
@@ -25790,9 +25790,13 @@ namespace sol {
 			else if (old_mode == LUA_GCINC) {
 				return gc_mode::incremental;
 			}
-#endif
 			return gc_mode::default_value;
 		}
+#else
+		gc_mode change_gc_mode_generational(int, int) {
+			return gc_mode::default_value;
+		}
+#endif
 
 		operator lua_State*() const {
 			return lua_state();

--- a/single/single.py
+++ b/single/single.py
@@ -304,17 +304,17 @@ os.makedirs(single_file_dir, exist_ok=True)
 os.makedirs(forward_single_file_dir, exist_ok=True)
 os.makedirs(config_single_file_dir, exist_ok=True)
 
-with open(single_file, 'w', encoding='utf-8') as f:
+with open(single_file, 'w', encoding='utf-8', newline='\r\n') as f:
 	if not args.quiet:
 		print('writing {}...'.format(single_file))
 	f.write(result)
 
-with open(forward_single_file, 'w', encoding='utf-8') as f:
+with open(forward_single_file, 'w', encoding='utf-8', newline='\r\n') as f:
 	if not args.quiet:
 		print('writing {}...'.format(forward_single_file))
 	f.write(forward_result)
 
-with open(config_single_file, 'w', encoding='utf-8') as f:
+with open(config_single_file, 'w', encoding='utf-8', newline='\r\n') as f:
 	if not args.quiet:
 		print('writing {}...'.format(config_single_file))
 	f.write(config_result)

--- a/tests/runtime_tests/source/usertypes.basic.cpp
+++ b/tests/runtime_tests/source/usertypes.basic.cpp
@@ -313,7 +313,7 @@ TEST_CASE("usertype/const-reference-no-collect", "Make sure const reference aren
 	//Should not collect anything.
 	lua.collect_gc();
 	lua.safe_script("getFooRefConst()");
-	//Should not collect anything. But it does!
+	//Should not collect anything.
 	lua.collect_gc();
 	foo.allow_destruction = true;
 }


### PR DESCRIPTION
Fixes for the issue where const references are incorrectly deleted by Lua GC, as described in a separate Issue (https://github.com/ThePhD/sol2/issues/1365).

This fixes the issue, and all tests passes, but it's not entirely clear to me what the impact is, and why the is_const check in push_reference was added to start with.

Note that I had to upgrade Clutch2 to handle an issue with building on glibc 2.34 (I'm on OpenSuSE Tumbleweed which uses 2.35).
I also had to handle compile warnings on gcc 12.1 which made compilation fail (which hopefully won't blow up on other compilers).
And since I'm on Linux I added a fix for generating Windows file ending for the single header.