### PR TITLE
@zach2good Add static_cast to unique_index arg to silence MSVC warning

### DIFF
--- a/include/sol/stack.hpp
+++ b/include/sol/stack.hpp
@@ -207,7 +207,7 @@ namespace sol {
 				int push_count = push(L, std::forward<T>(arg));
 				sol_c_assert(push_count == 1);
 				std::size_t unique_index = static_cast<std::size_t>(luaL_len(L, tableindex) + 1u);
-				lua_rawseti(L, tableindex, unique_index);
+				lua_rawseti(L, tableindex, static_cast<int>(unique_index));
 			}
 
 		} // namespace stack_detail


### PR DESCRIPTION
Hi there 👋 

I just updated to `v3.3.0` and was met with this warning (I have my warnings and warnings-and-errors cranked up):

```
  key_items.cpp
C:\ffxi\server\ext\sol\include\sol/sol.hpp(16554,1): error C2220: the following warning is treated as an error (compiling source file C:\ffxi\server\src\map\lua\lua_baseentity.cpp) [
C:\ffxi\server\build\src\map\xi_map.vcxproj]
C:\ffxi\server\ext\sol\include\sol/sol.hpp(26038): message : see reference to function template instantiation 'void sol::stack::stack_detail::raw_table_set<_Ty>(lua_State *,T &&,int)
' being compiled [C:\ffxi\server\build\src\map\xi_map.vcxproj]
          with
          [
              _Ty=int,
              T=int
          ] (compiling source file C:\ffxi\server\src\map\lua\lua_baseentity.cpp)
  linkshell_equip.cpp
C:\ffxi\server\src\map\lua\lua_baseentity.cpp(2842): message : see reference to function template instantiation 'sol::basic_table_core<false,sol::reference> &sol::basic_table_core<fa 
lse,sol::reference>::add<int>(int &&)' being compiled [C:\ffxi\server\build\src\map\xi_map.vcxproj]
C:\ffxi\server\src\map\lua\lua_baseentity.cpp(2842): message : see reference to function template instantiation 'sol::basic_table_core<false,sol::reference> &sol::basic_table_core<fa 
lse,sol::reference>::add<int>(int &&)' being compiled [C:\ffxi\server\build\src\map\xi_map.vcxproj]
C:\ffxi\server\ext\sol\include\sol/sol.hpp(16554,1): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data (compiling source file C:\ffxi\server\src\map 
\lua\lua_baseentity.cpp) [C:\ffxi\server\build\src\map\xi_map.vcxproj]
  linkshell_message.cpp
```

Fixed with this PR. 

Thanks for all the hard work!