### PR TITLE
Fix clang compiler warning

### DIFF
--- a/include/sol/protected_function_result.hpp
+++ b/include/sol/protected_function_result.hpp
@@ -101,7 +101,9 @@ namespace sol {
 
 #if SOL_IS_ON(SOL_COMPILER_GCC)
 #pragma GCC diagnostic push
+#if !SOL_IS_ON(SOL_COMPILER_CLANG)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #endif
 
 		template <typename T>

--- a/include/sol/stack_check_get_qualified.hpp
+++ b/include/sol/stack_check_get_qualified.hpp
@@ -32,7 +32,9 @@ namespace sol { namespace stack {
 
 #if SOL_IS_ON(SOL_COMPILER_GCC)
 #pragma GCC diagnostic push
+#if !SOL_IS_ON(SOL_COMPILER_CLANG)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #endif
 
 	namespace stack_detail {


### PR DESCRIPTION
**[why]**
Compiling with clang issues this warning
(clang 10.0 and 15.0 tested)
(single header sol v3.3.0 used)

```
../include/taskolib/sol/sol/sol.hpp:14541:32: warning: unknown warning group '-Wmaybe-uninitialized', ignored [-Wunknown-warning-option]
#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
                               ^
../include/taskolib/sol/sol/sol.hpp:17294:32: warning: unknown warning group '-Wmaybe-uninitialized', ignored [-Wunknown-warning-option]
#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
```

**[how]**
Check if the compiler does know the warning, before trying to turn the warning off.

_Edit: Add sol version_