### PR TITLE
Allow compiling with the CUDA 11.4 compiler

### DIFF
--- a/include/sol/stack_core.hpp
+++ b/include/sol/stack_core.hpp
@@ -1190,7 +1190,7 @@ namespace sol {
 		}
 
 		template <typename T>
-		decltype(auto) get_usertype(lua_State* L, int index = -lua_size_v<meta::unqualified_t<T>>) {
+		decltype(auto) get_usertype(lua_State* L, int index = -lua_size_v<meta::unqualified_t<T> >) {
 			record tracking {};
 			return get_usertype<T>(L, index, tracking);
 		}

--- a/include/sol/stack_push.hpp
+++ b/include/sol/stack_push.hpp
@@ -342,7 +342,7 @@ namespace sol { namespace stack {
 				return 1;
 			}
 			else if constexpr (std::is_same_v<Tu, luaL_Stream*>) {
-				luaL_Stream* source { std::forward<Args>(args)... };
+				luaL_Stream* source(std::forward<Args>(args)...);
 				luaL_Stream* stream = static_cast<luaL_Stream*>(detail::alloc_newuserdata(L, sizeof(luaL_Stream)));
 				stream->f = source->f;
 #if SOL_IS_ON(SOL_LUAL_STREAM_USE_CLOSE_FUNCTION)


### PR DESCRIPTION
Hello,

This pull request allows sol2 to be compiled by version 11.4 of the CUDA C++ compiler `nvcc`. It essentially consists of workarounds for compiler bugs, and I certainly understand the annoyance of changing one's code due to bad compilers, but if this is merged then the mainline version of sol2 will be able to support our High Performance Computing codes with no modifications.

Thank you for any time you spend reviewing this and considering it for merging, please let me know if there is anything I can do to help.

I don't think it should change any behavior, although the construction of a pointer by forwarded arguments change might be worth a look by someone with deeper C++ knowledge.