### PR TITLE
🛠 Review exhaustive check and get rid of a few Wall/pedwarn warnings

### DIFF
--- a/include/sol/stack_check_unqualified.hpp
+++ b/include/sol/stack_check_unqualified.hpp
@@ -608,7 +608,7 @@ namespace sol { namespace stack {
 		}
 
 		template <typename V, typename Handler>
-		static bool check_one(types<V>, lua_State* arg_L, int relindex, type indextype, Handler&& handler, record& tracking) {
+		static bool check_one(types<V>, lua_State* arg_L, int relindex, type, Handler&& handler, record& tracking) {
 			tracking.use(1);
 
 			size_t index = lua_absindex(arg_L, relindex);
@@ -645,7 +645,6 @@ namespace sol { namespace stack {
 				++idx;
 			loop_continue:;
 			}
-			return true;
 		}
 
 		template <typename Handler>

--- a/include/sol/stack_core.hpp
+++ b/include/sol/stack_core.hpp
@@ -370,10 +370,10 @@ namespace sol {
 
 			constexpr std::size_t initial_size = aligned_space_for<T*, unique_destructor, unique_tag, Real>();
 
-			void* pointer_adjusted;
-			void* dx_adjusted;
-			void* id_adjusted;
-			void* data_adjusted;
+			void* pointer_adjusted = nullptr;
+			void* dx_adjusted = nullptr;
+			void* id_adjusted = nullptr;
+			void* data_adjusted = nullptr;
 			bool result = attempt_alloc_unique(L,
 			     std::alignment_of_v<T*>,
 			     sizeof(T*),

--- a/include/sol/table_proxy.hpp
+++ b/include/sol/table_proxy.hpp
@@ -77,6 +77,15 @@ namespace sol {
 		table_proxy(Table table, T&& k) : tbl(table), key(std::forward<T>(k)) {
 		}
 
+		table_proxy(const table_proxy&) = default;
+		table_proxy(table_proxy&&) = default;
+		table_proxy& operator=(const table_proxy& right) {
+			return set(right);
+		}
+		table_proxy& operator=(table_proxy&& right) {
+			return set(std::move(right));
+		}
+
 		template <typename T>
 		table_proxy& set(T&& item) & {
 			tuple_set(std::make_index_sequence<std::tuple_size_v<meta::unqualified_t<key_type>>>(), std::forward<T>(item));
@@ -101,7 +110,7 @@ namespace sol {
 			return std::move(*this);
 		}
 
-		template <typename T>
+		template <typename T, std::enable_if_t<!std::is_same_v<meta::unqualified_t<T>, table_proxy>>* = nullptr>
 		table_proxy& operator=(T&& other) & {
 			using Tu = meta::unwrap_unqualified_t<T>;
 			if constexpr (!is_lua_reference_or_proxy_v<Tu> && meta::is_invocable_v<Tu>) {
@@ -112,7 +121,7 @@ namespace sol {
 			}
 		}
 
-		template <typename T>
+		template <typename T, std::enable_if_t<!std::is_same_v<meta::unqualified_t<T>, table_proxy>>* = nullptr>
 		table_proxy&& operator=(T&& other) && {
 			using Tu = meta::unwrap_unqualified_t<T>;
 			if constexpr (!is_lua_reference_or_proxy_v<Tu> && meta::is_invocable_v<Tu> && !detail::is_msvc_callable_rigged_v<T>) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ function(sol2_create_basic_test test_target_name target_sol)
 endfunction()
 
 add_subdirectory(inclusion)
+add_subdirectory(container_exhaustive)
 add_subdirectory(enum)
 add_subdirectory(environment)
 add_subdirectory(exceptions)

--- a/tests/container_exhaustive/source/exhaustive.cpp
+++ b/tests/container_exhaustive/source/exhaustive.cpp
@@ -39,10 +39,12 @@ inline namespace sol2_tests_exhaustive {
 
 	inline constexpr int FAILURE_CONSTANT = 1000;
 
+	inline constexpr int LINK_CONSTANT = 0xA837;
+
 	inline int ex_f0(sol::exhaustive<std::vector<Link>> ex_vec) {
 		const auto& vec = ex_vec.value();
 		for (const auto& elem : vec) {
-			REQUIRE(elem.value == 0);
+			REQUIRE(elem.value == LINK_CONSTANT);
 		}
 		return 0;
 	}
@@ -56,10 +58,11 @@ inline namespace sol2_tests_exhaustive {
 		return 1;
 	}
 
-	inline int ex_f2(sol::exhaustive<std::vector<NonLink>> ex_vec) {
+	inline int ex_f2(sol::exhaustive<std::vector<NonLink>> ex_vec, sol::this_state this_lua) {
 		const auto& vec = ex_vec.value();
+		void* address = static_cast<void*>(this_lua.lua_state());
 		for (const auto& elem : vec) {
-			REQUIRE(elem.value == nullptr);
+			REQUIRE(elem.value == address);
 		}
 		return 2;
 	}
@@ -74,9 +77,11 @@ TEST_CASE("large_integer/bool", "pass bool integral value to and from lua") {
 	sol::state lua;
 	lua.open_libraries(sol::lib::base);
 
+	void* address = lua.lua_state();
+
 	lua["FAILURE_CONSTANT"] = FAILURE_CONSTANT;
-	lua["link_obj"] = Link { 0 };
-	lua["nonlink_obj"] = NonLink { nullptr };
+	lua["link_obj"] = Link { LINK_CONSTANT };
+	lua["nonlink_obj"] = NonLink { address };
 
 	sol::optional<sol::error> setup_result = lua.safe_script(R"(
 		expect0_0 = { link_obj, link_obj, link_obj, link_obj }
@@ -89,22 +94,31 @@ TEST_CASE("large_integer/bool", "pass bool integral value to and from lua") {
 	REQUIRE_FALSE(setup_result.has_value());
 
 	lua.set_function("get_table_exhaustive", sol::overload(ex_f0, ex_f1, ex_f2, ex_ffail));
-
-	sol::optional<sol::error> result = lua.safe_script(R"(
-		result0_0 = get_table_exhaustive(expect0_0)
-		assert(result0_0 == 0)
-		result0_1 = get_table_exhaustive(expect0_1)
-		assert(result0_1 == FAILURE_CONSTANT)
-
-		result1_0 = get_table_exhaustive(expect1_0)
-		assert(result1_0 == 1)
-		result1_1 = get_table_exhaustive(expect1_1)
-		assert(result1_1 == FAILURE_CONSTANT)
-
-		result2_0 = get_table_exhaustive(expect2_0)
-		assert(result2_0 == 2)
-		result2_1 = get_table_exhaustive(expect2_1)
-		assert(result2_1 == FAILURE_CONSTANT)
-	)");
-	REQUIRE_FALSE(result.has_value());
+	{
+		sol::optional<sol::error> result = lua.safe_script(R"(
+			result0_0 = get_table_exhaustive(expect0_0)
+			assert(result0_0 == 0)
+			result0_1 = get_table_exhaustive(expect0_1)
+			assert(result0_1 == FAILURE_CONSTANT)
+		)");
+		REQUIRE_FALSE(result.has_value());
+	}
+	{
+		sol::optional<sol::error> result = lua.safe_script(R"(
+			result1_0 = get_table_exhaustive(expect1_0)
+			assert(result1_0 == 1)
+			result1_1 = get_table_exhaustive(expect1_1)
+			assert(result1_1 == FAILURE_CONSTANT)
+		)");
+		REQUIRE_FALSE(result.has_value());
+	}
+	{
+		sol::optional<sol::error> result = lua.safe_script(R"(
+			result2_0 = get_table_exhaustive(expect2_0)
+			assert(result2_0 == 2)
+			result2_1 = get_table_exhaustive(expect2_1)
+			assert(result2_1 == FAILURE_CONSTANT)
+		)");
+		REQUIRE_FALSE(result.has_value());
+	}
 }


### PR DESCRIPTION
We reviewed the exhaustive check/get warnings and manually tested it on Windows and Linux machines with Visual Studio (Windows) and GCC 9, 11 (Debian & Ubuntu).

The tests are passing, we manually added them to the general build, and further testing seems to indicate the feature is working as expected. We are in communication with a few stakeholders to obtain more relevant information, but this PR is just a general cleanup of the feature. OK to pull?