### PR TITLE
version: detects clang as MSVC and GCC

### DIFF
--- a/include/sol/version.hpp
+++ b/include/sol/version.hpp
@@ -95,7 +95,7 @@
 	#else
 		#define SOL_COMPILER_VCXX_I_ SOL_OFF
 	#endif
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && !defined(__clang__)
 	#define SOL_COMPILER_VCXX_I_ SOL_DEFAULT_ON
 #else
 	#define SOL_COMPILER_VCXX_I_ SOL_DEFAULT_OFF
@@ -107,7 +107,7 @@
 	#else
 		#define SOL_COMPILER_GCC_I_ SOL_OFF
 	#endif
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && !defined(__clang__)
 	#define SOL_COMPILER_GCC_I_ SOL_DEFAULT_ON
 #else
 	#define SOL_COMPILER_GCC_I_ SOL_DEFAULT_OFF


### PR DESCRIPTION
sol uses `__GNUC__` to detect GCC and `_MSC_VER` to detect MSVC. The problem is that clang defines both of them.