### PR TITLE
Add mention of sol2::sol2 alias in build.rst

### DIFF
--- a/documentation/source/build.rst
+++ b/documentation/source/build.rst
@@ -3,7 +3,7 @@ build
 
 sol2 is a header-only library.
 
-sol2 comes with a CMake script in the top level. It is primarily made for building and running the examples and tests, but it includes exported and configured targets (``sol2``, ``sol2_single``) for your use.
+sol2 comes with a CMake script in the top level. It is primarily made for building and running the examples and tests, but it includes exported and configured targets (``sol2``, ``sol2_single``) for your use. ``sol2::sol2`` alias is defined for the ``sol2`` target as well.
 
 sol2 also comes with a Meson Script. If things stop working, file a bug report.
 


### PR DESCRIPTION
I think it's useful to mention it in docs, since I had to look up the CMakeLists.txt to make sure that it exists. :)