### PR TITLE
Fix get_max_hp mehod in property example

### DIFF
--- a/examples/source/property.cpp
+++ b/examples/source/property.cpp
@@ -15,7 +15,7 @@ public:
 	}
 
 	int get_max_hp() const {
-		return hp;
+		return maxhp;
 	}
 
 	void set_max_hp(int value) {


### PR DESCRIPTION
The `get_max_hp` method erroneously returned the value of the `hp` member variable.