### PR TITLE
Fix build when LUA_COMPAT_BITLIB or LUA_COMPAT_5_2 are defined

### DIFF
--- a/include/sol/compatibility/lua_version.hpp
+++ b/include/sol/compatibility/lua_version.hpp
@@ -192,7 +192,7 @@
 #else
 	// Lua 5.2 only (deprecated in 5.3 (503)) (Can be turned on with Compat flags)
 	// Lua 5.2, or other versions of Lua with the compat flag, or Lua that is not 5.2 with the specific define (5.4.1 either removed it entirely or broke it)
-	#if (SOL_LUA_VERSION_I_ == 502) || (defined(LUA_COMPAT_BITLIB) && (LUA_COMPAT_BITLIB != 0)) || (SOL_LUA_VERSION_I_ < 504 && (defined(LUA_COMPAT_5_2) && (LUA_COMPAT_5_2 != 0)))
+	#if (SOL_LUA_VERSION_I_ == 502) || defined(LUA_COMPAT_BITLIB) || (SOL_LUA_VERSION_I_ < 504 && defined(LUA_COMPAT_5_2))
 		#define SOL_LUA_BIT32_LIB_I_ SOL_ON
 	#else
 		#define SOL_LUA_BIT32_LIB_I_ SOL_DEFAULT_OFF


### PR DESCRIPTION
Hi and thank you for sol2!

Lua may define the macros but leaves them empty. The code assumed they would contain a boolean value.

This is required to use sol2 with system Lua on Fedora 37 (see https://github.com/longturn/freeciv21/issues/1895)

Closes #1461.