### PR TITLE
🛠 Sometimes the conversion of sol::nested wrappers is not perfect.

### DIFF
--- a/include/sol/stack_get_unqualified.hpp
+++ b/include/sol/stack_get_unqualified.hpp
@@ -257,6 +257,10 @@ namespace sol { namespace stack {
 					return static_cast<actual>(r);
 				}
 			}
+			else if constexpr (!std::is_reference_v<X> && meta::is_specialization_of_v<X, nested>) {
+				using NestedX = typename meta::unqualified_t<X>::nested_type;
+				return stack_detail::unchecked_unqualified_get<NestedX>(L, index, tracking);
+			}
 			else {
 				return stack_detail::unchecked_unqualified_get<Tu>(L, index, tracking);
 			}


### PR DESCRIPTION
```c++
struct Vector {
	int x;
	int y;
};

template <class Handler>
bool sol_lua_check(sol::types<Vector>, ::lua_State* L, int index,
     Handler&& handler, sol::stack::record& tracking) {
    // It can pass the type check correctly.
	return sol::stack::check<sol::lua_table>(
	     L, index, std::forward<Handler>(handler), tracking);
}

Vector sol_lua_get(sol::types<Vector>, ::lua_State* L, int idx,
     sol::stack::record& tracking) {
    // However, it is not possible to convert the type.
	tracking.use(1);
	sol::table t = sol::table(L, idx);
	return { t["x"].get<int>(), t["y"].get<int>() };
}

int main() {
	sol::state lua;
	lua.open_libraries(sol::lib::base);
	lua.script("vectors = { {x = 3, y = 6}, {x = 6,y=3} }");
	auto v = lua["vectors"].get<std::vector<Vector>>();// error.

	return 0;
}
```