### PR TITLE
Print aux_message if there is no message

### DIFF
--- a/include/sol/error_handler.hpp
+++ b/include/sol/error_handler.hpp
@@ -84,7 +84,7 @@ namespace sol {
 
 	inline int push_type_panic_string(lua_State* L, int index, type expected, type actual, string_view message, string_view aux_message) noexcept {
 		const char* err = message.size() == 0
-		     ? (aux_message.size() == 0 ? "stack index %d, expected %s, received %s" : "stack index %d, expected %s, received %s: %s")
+		     ? (aux_message.size() == 0 ? "stack index %d, expected %s, received %s" : "stack index %d, expected %s, received %s: %s%s")
 		     : "stack index %d, expected %s, received %s: %s %s";
 		const char* type_name = expected == type::poly ? "anything" : lua_typename(L, static_cast<int>(expected));
 		{


### PR DESCRIPTION
The aux_message would not be printed if the message was empty because the fstring `%s` is filled with the empty message argument.

Before: `stack index 2, expected string, received no value:`

After: `stack index 2, expected string, received no value: (bad argument into 'sol::basic_table_core<false, sol::basic_reference<false> >(Rml::Context&, const std::__cxx11::basic_string<char>&, sol::basic_object<sol::basic_reference<false> >, sol::this_state)') `