### PR TITLE
Add limits header explicitly to be compatible with gcc11

### DIFF
--- a/include/sol/stack_core.hpp
+++ b/include/sol/stack_core.hpp
@@ -45,6 +45,7 @@
 #include <sstream>
 #include <optional>
 #include <type_traits>
+#include <limits>
 
 namespace sol {
 	namespace detail {


### PR DESCRIPTION
Based on https://gcc.gnu.org/gcc-11/porting_to.html `Header dependency changes`, new versions `>gcc10` have removed some implicit includes (again) which causes codebases relying on those to fail.

This little line will fix compatibility with gcc11