### PR TITLE
Fix compilation with `-Wtype-limits`

### DIFF
--- a/tests/coroutines/source/array_proxy_lifetime.cpp
+++ b/tests/coroutines/source/array_proxy_lifetime.cpp
@@ -59,7 +59,7 @@ inline namespace sol2_regression_test_coroutines_array_proxy_lifetime {
 
 			value_type operator*() const {
 				size_t size = a.mpParent.children.size();
-				if (index >= 0 && index < size) {
+				if (index < size) {
 					return a.mpParent.children[index];
 				}
 				return std::weak_ptr<A>();


### PR DESCRIPTION
CI [currently fails](https://github.com/ThePhD/sol2/actions/runs/9920798892/job/27408062139), because of a check if [an unsigned integer is greater or equal to zero](https://github.com/ThePhD/sol2/blob/2b0d2fe8ba0074e16b499940c4f3126b9c7d3471/tests/coroutines/source/array_proxy_lifetime.cpp#L62). This PR removes the check, getting rid of a warning in GCC and making CI green.
Clang emits a similar warning if `-Wtype-limits` is passed (enabling `-Wtautological-unsigned-zero-compare`), which isn't enabled through `-pedantic -Wpedantic -Wall -Wextra -Werror` (thus Apple-Clang doesn't complain).

---

**Aside**:

All `.clang-format`s are currently broken [at least with 18.1], because of a duplicate [`AfterStruct`](https://github.com/ThePhD/sol2/blob/2b0d2fe8ba0074e16b499940c4f3126b9c7d3471/.clang-format#L77).
<details><summary>Diff</summary>

```diff
diff --git a/.clang-format b/.clang-format
index f75a5542..9a25bae9 100644
--- a/.clang-format
+++ b/.clang-format
@@ -74,7 +74,6 @@ BraceWrapping:
   AfterControlStatement: false
   AfterClass: false
   AfterNamespace: false
-  AfterStruct: false
   AfterUnion: false
   BeforeElse: true
   BeforeCatch: true
diff --git a/documentation/.clang-format b/documentation/.clang-format
index 00ef7c2c..b2a47e16 100644
--- a/documentation/.clang-format
+++ b/documentation/.clang-format
@@ -74,7 +74,6 @@ BraceWrapping:
   AfterControlStatement: false
   AfterClass: false
   AfterNamespace: false
-  AfterStruct: false
   AfterUnion: false
   BeforeElse: true
   BeforeCatch: true
diff --git a/examples/.clang-format b/examples/.clang-format
index 9807f392..1c209463 100644
--- a/examples/.clang-format
+++ b/examples/.clang-format
@@ -74,7 +74,6 @@ BraceWrapping:
   AfterControlStatement: false
   AfterClass: false
   AfterNamespace: false
-  AfterStruct: false
   AfterUnion: false
   BeforeElse: true
   BeforeCatch: true
```
</details>