### PR TITLE
Fix implicitly deleted operator= for variadic_results

### DIFF
--- a/include/sol/variadic_results.hpp
+++ b/include/sol/variadic_results.hpp
@@ -58,9 +58,6 @@ namespace sol {
 		          std::is_same<meta::unqualified_t<Arg0>, protected_function_result>> = meta::enabler>
 		basic_variadic_results(Arg0&& arg0, Args&&... args) : base_t(std::forward<Arg0>(arg0), std::forward<Args>(args)...) {
 		}
-
-		basic_variadic_results(const basic_variadic_results&) = default;
-		basic_variadic_results(basic_variadic_results&&) = default;
 	};
 
 	struct variadic_results : public basic_variadic_results<> {


### PR DESCRIPTION
Hey,

`sol::variadic_results` move and copy assignment is implicitly deleted because `sol::basic_variadic_results` declares a move constructor with `= default`. Such declaration for copy and move constructor is not necessary, removing them would re-enable move and copy assignment.

Alternatively with C++20 support move and copy assignment could be `= default`-ed too.
Alternatively move and copy assignment could be could be user provided (with static_cast to base).

GCC 14.2 output:
```C++
error: use of deleted function 'sol::variadic_results& sol::variadic_results::operator=(sol::variadic_results&&)'
note: 'sol::variadic_results& sol::variadic_results::operator=(sol::variadic_results&&)' is implicitly deleted because the default definition would be ill-formed:
...
error: use of deleted function 'constexpr sol::basic_variadic_results<>& sol::basic_variadic_results<>::operator=(const sol::basic_variadic_results<>&)'
note: 'constexpr sol::basic_variadic_results<>& sol::basic_variadic_results<>::operator=(const sol::basic_variadic_results<>&)' is implicitly declared as deleted because 'sol::basic_variadic_results<>' declares a move constructor or move assignment operator
...
```