### PR TITLE
Use main_object in dynamic_object example

### DIFF
--- a/examples/source/dynamic_object.cpp
+++ b/examples/source/dynamic_object.cpp
@@ -10,14 +10,16 @@
 struct dynamic_object {
 	std::unordered_map<std::string, sol::object> entries;
 
-	void dynamic_set(std::string key, sol::stack_object value) {
+	// Uses main_object since we may get objects from coroutine
+	// threads that might die before us.
+	void dynamic_set(std::string key, sol::main_object value) {
 		auto it = entries.find(key);
 		if (it == entries.cend()) {
 			entries.insert(
 			     it, { std::move(key), std::move(value) });
 		}
 		else {
-			std::pair<const std::string, sol::object>& kvp
+			std::pair<const std::string, sol::main_object>& kvp
 			     = *it;
 			sol::object& entry = kvp.second;
 			entry = sol::object(std::move(value));

--- a/examples/source/dynamic_object.cpp
+++ b/examples/source/dynamic_object.cpp
@@ -19,7 +19,7 @@ struct dynamic_object {
 			     it, { std::move(key), std::move(value) });
 		}
 		else {
-			std::pair<const std::string, sol::main_object>& kvp
+			std::pair<const std::string, sol::object>& kvp
 			     = *it;
 			sol::object& entry = kvp.second;
 			entry = sol::object(std::move(value));


### PR DESCRIPTION
It can be easily overlooked (and hard to debug) that you should not store objects that haven't been locked to the main thread. (https://sol2.readthedocs.io/en/latest/threading.html)

Using main_object in the example lets people see this quicker ;)

Fixes #1640