### PR TITLE
Simplify sol::optional<T&>::emplace

### DIFF
--- a/include/sol/optional_implementation.hpp
+++ b/include/sol/optional_implementation.hpp
@@ -2186,12 +2186,8 @@ namespace sol {
 		/// one.
 		///
 		/// \group emplace
-		template <class... Args>
-		T& emplace(Args&&... args) noexcept {
-			static_assert(std::is_constructible<T, Args&&...>::value, "T must be constructible with Args");
-
-			*this = nullopt;
-			new (static_cast<void*>(this)) optional(std::in_place, std::forward<Args>(args)...);
+		T& emplace(T& arg) noexcept {
+			m_value = &arg;
 			return **this;
 		}
 


### PR DESCRIPTION
See comment on #1606: https://github.com/ThePhD/sol2/pull/1606#issuecomment-2481429973

The implementation for `emplace` in the `optional<T>` specialisation is needlessly complex, and the `static_assert` is testing the wrong thing.

Consider:
```c++
	template <class T>
	class optional<T&> {
...
		template <class... Args>
		T& emplace(Args&&... args) noexcept {
			static_assert(std::is_constructible<T, Args&&...>::value, "T must be constructible with Args");

			*this = nullopt;
			new (static_cast<void*>(this)) optional(std::in_place, std::forward<Args>(args)...);
			return **this;
		}
...
	};
```

Now look at the `static_assert` – it’s testing that `T` can be constructed using the argument types passed to `emplace`.  However, the `optional<T&>` doesn’t hold `T`, it logically holds `T&` (although it’s implemented using `T*` to allow assignment).  The only thing that `T&` can be constructed with is `T&`.  It makes no sense to use variadic arguments.

When called with `T&`, the `static_assert` only succeeds by chance when `T` is copy constructible.  It will fail if it isn’t, and it will succeed for other things that `T` can be constructed with when it shouldn’t.

For example, the `static_assert` will succeed here, but it won’t work:
```c++
sol::optional<std::string&> o; // optional<T&> specialisation where T = std::string
o.emplace(size_t(4), 'X'); // the static_assert passes because T (i.e. std::string) can be constructed with (size_t, char), however it won't work because it needs a reference to a std::string
```

Conversely, this won’t work when it should
```c++
sol::optional<std::unique_ptr<int>&> o; // optional<T&> specialisation where T = std::unique_ptr<int>
std::uniqe_ptr<int> p;
o.emplace(p); // static_assert fails because T (i.e. std::unique_ptr<int>) can't be constructed from std::uniqe_ptr<int>& as it isn't copyable
```

Since you know `T*` is trivially destructible and copyable, you could implement `emplace` as:
```c++
		T& emplace(T& arg) noexcept {
			m_value = &arg;
			return **this;
		}
```

