### PR TITLE
`use_luajit` option for Meson builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,16 @@ else
 	lua_cpp = 'false'
 endif
 
-lua_dep = dependency('lua', fallback: [ 'lua', 'lua_dep' ], default_options: [ 'lua_cpp=' + lua_cpp ])
+if get_option('use_luajit')
+	luadep_name = 'luajit'
+	luadep_options = []
+	lua_cpp = 'false'
+else
+	luadep_name = 'lua'
+	luadep_options = [ 'lua_cpp=' + lua_cpp ]
+endif
+
+lua_dep = dependency(luadep_name, fallback: [ luadep_name, luadep_name + '_dep' ], default_options: luadep_options)
 
 # Set compiler flags if we're compiling lua as C++.
 compile_args = []

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,5 @@
 option('single', type: 'boolean', value: false, description: 'Generate the sol2 single header and expose the corresponding build targets')
 option('lua_cpp', type: 'boolean', value: false, description: 'Compile lua as C++ code')
+
+# Designed to work with the luajit wrapDB package provided by meson, others are a toss-up
+option('use_luajit', type: 'boolean', value: false, description: 'Search for luajit dep, implies lua_cpp=false')


### PR DESCRIPTION
Works with the Meson WrapDB LuaJIT, other packages should work fine as long as they provide either `luajit` or `luajit_dep`.

Thanks for the amazing library :]