### PR TITLE
Faster track for lightuserdata_value

### DIFF
--- a/include/sol/stack_check_qualified.hpp
+++ b/include/sol/stack_check_qualified.hpp
@@ -28,7 +28,7 @@
 
 namespace sol { namespace stack {
 
-	template <typename X, type expected, typename>
+	template <typename X, typename>
 	struct qualified_checker {
 		template <typename Handler>
 		static bool check(lua_State* L, int index, Handler&& handler, record& tracking) {

--- a/include/sol/stack_check_unqualified.hpp
+++ b/include/sol/stack_check_unqualified.hpp
@@ -389,9 +389,7 @@ namespace sol { namespace stack {
 					return success;
 				}
 				else if constexpr (meta::is_specialization_of_v<T, user>) {
-					unqualified_checker<lightuserdata_value, type::userdata> c;
-					(void)c;
-					return c.check(L_, index, std::forward<Handler>(handler), tracking);
+					return stack::unqualified_check<detail::as_value_tag<lightuserdata_value>>(L_, index, std::forward<Handler>(handler), tracking);
 				}
 				else {
 					if constexpr (std::is_pointer_v<T>) {

--- a/include/sol/stack_core.hpp
+++ b/include/sol/stack_core.hpp
@@ -571,7 +571,7 @@ namespace sol {
 
 		template <typename T, type t, typename = void>
 		struct unqualified_checker;
-		template <typename T, type t, typename = void>
+		template <typename T, typename = void>
 		struct qualified_checker;
 
 		template <typename T, typename = void>
@@ -1002,8 +1002,7 @@ namespace sol {
 				return sol_lua_check(types<T>(), L, index, std::forward<Handler>(handler), tracking);
 			}
 			else {
-				using Tu = meta::unqualified_t<T>;
-				qualified_checker<T, lua_type_of_v<Tu>> c{};
+				qualified_checker<T> c{};
 				return c.check(L, index, std::forward<Handler>(handler), tracking);
 			}
 		}


### PR DESCRIPTION
Skips 4 frames and some template instantiations for a fixed type `lightuserdata_value` that does not depend on `T`

Example based on sol2.tests.environment:
![lightuserdata_value_faster_track](https://github.com/user-attachments/assets/c23bca25-31a9-4b42-ba81-81ce2445f84f)
