### PR TITLE
Better utilize existing Lua 5.3 compatibility layer

### DIFF
--- a/include/sol/reference.hpp
+++ b/include/sol/reference.hpp
@@ -221,9 +221,9 @@ namespace sol {
 #if SOL_LUA_VERSION_I_ < 502
 		if (L_ == nullptr)
 			return backup_if_unsupported_;
-		lua_getglobal(L_, detail::default_main_thread_name());
+		type t = static_cast<type>(lua_getglobal(L_, detail::default_main_thread_name()));
 		auto pp = stack::pop_n(L_, 1);
-		if (type_of(L_, -1) == type::thread) {
+		if (t == type::thread) {
 			return lua_tothread(L_, -1);
 		}
 		return backup_if_unsupported_;

--- a/include/sol/stack_check_unqualified.hpp
+++ b/include/sol/stack_check_unqualified.hpp
@@ -545,8 +545,8 @@ namespace sol { namespace stack {
 #endif // make sure stack doesn't overflow
 					auto pn = stack::pop_n(L_, 1);
 					lua_pushstring(L_, &detail::base_class_check_key()[0]);
-					lua_rawget(L_, metatableindex);
-					if (type_of(L_, -1) != type::lua_nil) {
+					type t = static_cast<type>(lua_rawget(L_, metatableindex));
+					if (t != type::lua_nil) {
 						void* basecastdata = lua_touserdata(L_, -1);
 						detail::inheritance_check_function ic = reinterpret_cast<detail::inheritance_check_function>(basecastdata);
 						success = ic(usertype_traits<T>::qualified_name());
@@ -627,8 +627,7 @@ namespace sol { namespace stack {
 				bool isnil = false;
 				for (; vi < static_cast<int>(lua_size<V>::value); ++vi) {
 					lua_pushinteger(arg_L, i);
-					lua_gettable(arg_L, static_cast<int>(index));
-					type vt = type_of(arg_L, -1);
+					type vt = static_cast<type>(lua_gettable(arg_L, static_cast<int>(index)));
 					isnil = vt == type::lua_nil;
 					if (isnil) {
 						if (i == 0) {

--- a/include/sol/stack_get_unqualified.hpp
+++ b/include/sol/stack_get_unqualified.hpp
@@ -407,8 +407,7 @@ namespace sol { namespace stack {
 				bool isnil = false;
 				for (int vi = 0; vi < lua_size<V>::value; ++vi) {
 					lua_pushinteger(L, i);
-					lua_gettable(L, index);
-					type vt = type_of(L, -1);
+					type vt = static_cast<type>(lua_gettable(L, index));
 					isnil = vt == type::lua_nil;
 					if (isnil) {
 						if (i == 0) {
@@ -523,8 +522,7 @@ namespace sol { namespace stack {
 				bool isnil = false;
 				for (int vi = 0; vi < lua_size<V>::value; ++vi) {
 					lua_pushinteger(L, i);
-					lua_gettable(L, index);
-					type t = type_of(L, -1);
+					type t = static_cast<type>(lua_gettable(L, index));
 					isnil = t == type::lua_nil;
 					if (isnil) {
 						if (i == 0) {
@@ -905,8 +903,8 @@ namespace sol { namespace stack {
 			bool has_derived = derive<T>::value || weak_derive<T>::value;
 			if (has_derived) {
 				if (lua_getmetatable(L, index) == 1) {
-					lua_getfield(L, -1, &detail::base_class_cast_key()[0]);
-					if (type_of(L, -1) != type::lua_nil) {
+					type t = static_cast<type>(lua_getfield(L, -1, &detail::base_class_cast_key()[0]));
+					if (t != type::lua_nil) {
 						void* basecastdata = lua_touserdata(L, -1);
 						detail::inheritance_cast_function ic = reinterpret_cast<detail::inheritance_cast_function>(basecastdata);
 						// use the casting function to properly adjust the pointer for the desired T

--- a/include/sol/stack_push.hpp
+++ b/include/sol/stack_push.hpp
@@ -794,7 +794,7 @@ namespace sol { namespace stack {
 #if SOL_IS_ON(SOL_SAFE_STACK_CHECK)
 			luaL_checkstack(L, 1, detail::not_enough_stack_space_string);
 #endif // make sure stack doesn't overflow
-			lua_pushlstring(L, str, std::char_traits<char>::length(str));
+			lua_pushlstring(L, str, N - 1);
 			return 1;
 		}
 
@@ -875,7 +875,7 @@ namespace sol { namespace stack {
 			luaL_checkstack(L, 1, detail::not_enough_stack_space_string);
 #endif // make sure stack doesn't overflow
 			const char* str_as_char = reinterpret_cast<const char*>(static_cast<const char8_t*>(str));
-			lua_pushlstring(L, str_as_char, std::char_traits<char>::length(str_as_char));
+			lua_pushlstring(L, str_as_char, N - 1);
 			return 1;
 		}
 


### PR DESCRIPTION
It seems that the compatibility layer for Lua 5.3 is required. In a few places, Sol does not take advantage of that and uses separate C API calls. This PR proposes to better utilize the compatibility layer.