### PR TITLE
Although I don't know what it is, but it seems that it should be...

### DIFF
--- a/include/sol/usertype_container.hpp
+++ b/include/sol/usertype_container.hpp
@@ -1189,7 +1189,7 @@ namespace sol {
 			static int next_associative(std::true_type, lua_State* L_) {
 				iter& i = stack::unqualified_get<user<iter>>(L_, 1);
 				auto& it = i.it();
-				auto& end = i.end();
+				auto& end = i.sen();
 				if (it == end) {
 					return stack::push(L_, lua_nil);
 				}


### PR DESCRIPTION
CHECK it...

fixed like this:
lua["map"] = std::map<int, int> {{1,2},{3,4}};