### PR TITLE
Fix missing Lua::Lua target when using system Lua

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,10 @@ if (sol2-is-top-level-project)
 		set(LUA_LIBRARIES ${lualib})
 	endif()
 
+	if(NOT TARGET Lua::Lua)
+		add_library(Lua::Lua ALIAS ${lualib})
+	endif()
+
 	if (NOT LUA_FOUND AND NOT LUABUILD_FOUND)
 		message(FATAL_ERROR "sol2 Lua \"${SOL2_LUA_VERSION}\" not found and could not be targeted for building")
 	endif()


### PR DESCRIPTION
Enabling tests/examples when using an installed version of Lua results in 

```
CMake Error at examples/CMakeLists.txt:26 (target_link_libraries):
  Target "..." links to:

    Lua::Lua

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```