### PR TITLE
Reduce `cmake_minimum_required` to 3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 # # # # sol2
 # # # Required minimum version statement
-cmake_minimum_required(VERSION 3.26.0)
+cmake_minimum_required(VERSION 3.22)
 # # # Project Include - file that is included after project declaration is finished
 set(CMAKE_PROJECT_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Includes/Project.cmake")
 

--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 # # # # sol2, documentation generation
 # # # Required minimum version statement
-cmake_minimum_required(VERSION 3.26.0)
+cmake_minimum_required(VERSION 3.22)
 	
 find_package(Doxygen REQUIRED)
 find_package(Python3 REQUIRED)

--- a/single/CMakeLists.txt
+++ b/single/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 # # # # sol3, single
 # # # Required minimum version statement
-cmake_minimum_required(VERSION 3.26.0)
+cmake_minimum_required(VERSION 3.22)
 
 find_package(Python3 REQUIRED)
 


### PR DESCRIPTION
Ubuntu 22.04 CMake is 3.22.
Debian stable CMake is 3.25.
Debian oldstable (EOL in 2026) has CMake 3.25 in bullseye-backports.