### PR TITLE
Fix memory leak when indexing user types

### DIFF
--- a/include/sol/reference.hpp
+++ b/include/sol/reference.hpp
@@ -828,6 +828,8 @@ namespace sol {
 		stateless_reference_equals(lua_State* L_) noexcept : stateless_stack_reference_equals(L_) {
 		}
 
+		using stateless_stack_reference_equals::operator();
+
 		bool operator()(const lua_nil_t& lhs, const stateless_reference& rhs) const noexcept {
 			return rhs.equals(lua_state(), lhs);
 		}
@@ -837,6 +839,14 @@ namespace sol {
 		}
 
 		bool operator()(const stateless_reference& lhs, const stateless_reference& rhs) const noexcept {
+			return lhs.equals(lua_state(), rhs);
+		}
+
+		bool operator()(const stateless_stack_reference& lhs, const stateless_reference& rhs) const noexcept {
+			return rhs.equals(lua_state(), lhs);
+		}
+
+		bool operator()(const stateless_reference& lhs, const stateless_stack_reference& rhs) const noexcept {
 			return lhs.equals(lua_state(), rhs);
 		}
 	};
@@ -877,6 +887,8 @@ namespace sol {
 
 		stateless_reference_hash(lua_State* L_) noexcept : stateless_stack_reference_hash(L_) {
 		}
+
+		using stateless_stack_reference_hash::operator();
 
 		result_type operator()(const stateless_reference& lhs) const noexcept {
 			std::hash<const void*> h;

--- a/include/sol/usertype_storage.hpp
+++ b/include/sol/usertype_storage.hpp
@@ -502,7 +502,11 @@ namespace sol { namespace u_detail {
 					stateless_reference* target = nullptr;
 					{
 						stack_reference k = stack::get<stack_reference>(L, 2);
+#if __cpp_lib_generic_unordered_lookup >= 201811L
 						auto it = self.auxiliary_keys.find(k);
+#else
+						auto it = self.auxiliary_keys.find(basic_reference(k));
+#endif
 						if (it != self.auxiliary_keys.cend()) {
 							target = &it->second;
 						}

--- a/tests/regression_tests/1716/CMakeLists.txt
+++ b/tests/regression_tests/1716/CMakeLists.txt
@@ -20,8 +20,26 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-# # # # sol2 tests
+# # # # sol2 tests - simple regression tests
 
-add_subdirectory(1011)
-add_subdirectory(1716)
-add_subdirectory(simple)
+file(GLOB_RECURSE sources
+	LIST_DIRECTORIES FALSE
+	CONFIG_DEPENDS source/*.cpp)
+
+sol2_create_basic_test(sol2.tests.regression_1716 sol2::sol2 ${sources})
+sol2_create_basic_test(sol2.tests.regression_1716.SOL_ALL_SAFETIES_ON sol2::sol2 ${sources})
+target_compile_options(sol2.tests.regression_1716
+	PRIVATE
+	${--allow-unreachable-code})
+target_compile_definitions(sol2.tests.regression_1716.SOL_ALL_SAFETIES_ON
+	PRIVATE
+	SOL_ALL_SAFETIES_ON=1)
+target_compile_options(sol2.tests.regression_1716.SOL_ALL_SAFETIES_ON
+	PRIVATE
+	${--allow-unreachable-code})
+if (SOL2_TESTS_SINGLE)
+	sol2_create_basic_test(sol2.single.tests.regression_1716 sol2::sol2::single ${sources})
+	target_compile_options(sol2.single.tests.regression_1716
+		PRIVATE
+		${--allow-unreachable-code})
+endif()

--- a/tests/regression_tests/1716/source/1716 - registry indexing leak.cpp
+++ b/tests/regression_tests/1716/source/1716 - registry indexing leak.cpp
@@ -1,0 +1,61 @@
+// sol2
+
+// The MIT License (MIT)
+
+// Copyright (c) 2013-2022 Rapptz, ThePhD and contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <catch2/catch_all.hpp>
+
+#include <sol/sol.hpp>
+
+TEST_CASE("#1716 - index and newindex should not leak values into the registry", "[sol2][regression][issue1716]") {
+	class vector {
+	public:
+		vector() = default;
+
+		static int my_index(vector&, int) {
+			return 0;
+		}
+
+		static void my_new_index(vector&, int, int) {
+			return;
+		}
+	};
+
+	sol::state lua;
+	lua.open_libraries(sol::lib::base);
+	lua.new_usertype<vector>("vector",
+	     sol::constructors<sol::types<>>(), //
+	     sol::meta_function::index,
+	     &vector::my_index, //
+	     sol::meta_function::new_index,
+	     &vector::my_new_index);
+	auto begin = lua.registry().size();
+	lua.script(R"(
+			local v = vector.new()
+			local unused = 0
+			for i=1,100 do
+				unused = v[1]
+				v[1] = 1
+			end
+		)");
+
+	REQUIRE(lua.registry().size() <= begin + 1);
+}

--- a/tests/regression_tests/1716/source/main.cpp
+++ b/tests/regression_tests/1716/source/main.cpp
@@ -1,0 +1,31 @@
+// sol2
+
+// The MIT License (MIT)
+
+// Copyright (c) 2013-2022 Rapptz, ThePhD and contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#define CATCH_CONFIG_RUNNER
+
+#include <catch2/catch_all.hpp>
+
+int main(int argc, char* argv[]) {
+	int result = Catch::Session().run(argc, argv);
+	return result;
+}


### PR DESCRIPTION
`sol::u_detail::usertype_storage_base::self_index_call` contains `auto it = self.auxiliary_keys.find(k)`. `k` is a `stack_reference` and `auxiliary_keys` an unordered map with `stateless_reference` keys.

When compiled with Visual Studio 2022, `k` is implicitly converted to a `stateless_reference` via `stateless_reference(const stack_reference&)` and `stateless_reference(lua_State*, int)`. The latter adds a reference to the registry through `ref = luaL_ref(L_, LUA_REGISTRYINDEX)`, but `stateless_reference`'s destructor doesn't call `deref` so the registry table retains the value even after the call to `find` completes.

I don't know if `stateless_reference` should have a destructor that takes care of this. If not, I'd say its constructors should probably be marked `explicit` to avoid doing this by accident. Regardless, this PR skirts around that by avoiding the conversion in the first place. Which seems desirable.

I don't know if this affects other compilers/standard libraries/code paths. @magicaldave's comment on https://gitlab.com/OpenMW/openmw/-/issues/8614 suggests that some platforms might be unaffected.