### PR TITLE
Replace evergreen-tree byte encoding with Unicode encoding to prevent VS warnings

### DIFF
--- a/include/sol/inheritance.hpp
+++ b/include/sol/inheritance.hpp
@@ -53,12 +53,12 @@ namespace sol {
 		}
 
 		inline decltype(auto) base_class_index_propogation_key() {
-			static const auto& key = u8"\xF0\x9F\x8C\xB2.index";
+			static const auto& key = u8"\U0001F332.index";
 			return key;
 		}
 
 		inline decltype(auto) base_class_new_index_propogation_key() {
-			static const auto& key = u8"\xF0\x9F\x8C\xB2.new_index";
+			static const auto& key = u8"\U0001F332.new_index";
 			return key;
 		}
 


### PR DESCRIPTION
The latest Visual Studio compiler raises a warning in our client code:
`sol2\include\sol\inheritance.hpp(56,29): warning C5321: nonstandard extension used \'xF0\' as a multi-bute utf-8 character. Use \u instead for cross platform compatibility or \'Zc:u8EscapeEncoding\' to disable the extension.`

I raised [here](https://developercommunity.visualstudio.com/t/Warning-about-encoding-an-utf-8-characte/10913756) an issue at MS. At that time adding the recommended compiler switch was the easier solution. But we are now facing the problem in more and more products who use the Sol library and so I decided to create this PR.

I noticed during my fix that the `base_class_index_propagation_key()` function and the one below are nowhere referenced in the whole repo. Purpose or accident?
